### PR TITLE
Setup django admin for models

### DIFF
--- a/testbed/core/admin.py
+++ b/testbed/core/admin.py
@@ -89,10 +89,3 @@ class PortabilityOutboxAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
-
-    def get_readonly_fields(self, request, obj=None):
-        return [f.name for f in self.model._meta.fields] + [
-            'get_create_activities',
-            'get_like_activities',
-            'get_follow_activities'
-        ]


### PR DESCRIPTION
This PR set up Django Admin Interface for our ActivityPub Data Models

PortabilityOutbox admin view was modified to display activities grouped by type but only displaying the ones that correspondent to the Actor's outbox.

- Added three separate readonly fields for different activity types:
  - Create Activities: Shows notes creation and actor profile creation
  - Like Activities: Shows liked notes
  - Follow Activities: Shows followed actors
- Each section displays "No activities" when empty
- Maintained read-only permissions and prevented add/delete operations

We could go for a more stylish view if necessary.

Closes #36 

