### PR TITLE
feat(factories): Implement dual-actor factories and update test suite

### DIFF
--- a/testbed/core/factories.py
+++ b/testbed/core/factories.py
@@ -12,8 +12,10 @@ from testbed.core.models import (
 
 
 class UserFactory(DjangoModelFactory):
+    # Provides options to create users with or without associated actors
     class Meta:
         model = User
+        skip_postgeneration_save = True  # Prevents automatic save after creation
 
     username = factory.Sequence(lambda n: f"user_{n}")
     email = factory.LazyAttribute(lambda o: f"{o.username}@example.com")
@@ -23,40 +25,67 @@ class UserFactory(DjangoModelFactory):
     is_staff = False
     is_active = True
 
-    @classmethod
-    def _after_postgeneration(cls, instance, create, results=None):
-        if create:
-            instance.save()
+    @factory.post_generation
+    def with_actors(self, create, extracted, **kwargs):
+        """Optional hook to create associated actors for the user
+        
+        Usage:
+            UserFactory(with_actors=True)  # Creates user with both actors
+            UserFactory(with_actors=False)  # Creates just the user
+        """
+        if not create:
+            return
+        
+        self.save()
+        if extracted:
+            Actor.objects.create_actors_for_user(self)
 
-
+# Factory for creating Actor instances
+# Provides methods for creating source actors, destination actors, or pairs.
 class ActorFactory(DjangoModelFactory):
     class Meta:
         model = Actor
+        skip_postgeneration_save = True  # Prevents duplicate initialization
 
-    user = factory.SubFactory(UserFactory)
+    user = factory.SubFactory(UserFactory, with_actors=False)
     username = factory.LazyAttribute(lambda o: f"{o.user.username}_{o.role}")
     role = factory.Iterator([Actor.ROLE_SOURCE, Actor.ROLE_DESTINATION])
     previously = factory.List([])
 
+    @classmethod
+    def create_source_actor(cls, **kwargs):
+        return cls.create(role=Actor.ROLE_SOURCE, **kwargs)
+
+    @classmethod
+    def create_destination_actor(cls, **kwargs):
+        return cls.create(role=Actor.ROLE_DESTINATION, **kwargs)
+
+    @classmethod
+    def create_pair(cls, **kwargs):
+        user = UserFactory.create(with_actors=False)
+        return Actor.objects.create_actors_for_user(user, **kwargs)
+
 
 class NoteFactory(DjangoModelFactory):
+    # Notes can only be created by source actors
     class Meta:
         model = Note
 
-    actor = factory.SubFactory(ActorFactory)
+    actor = factory.SubFactory(ActorFactory, role=Actor.ROLE_SOURCE)
     content = factory.Faker("text", max_nb_chars=200)
     visibility = factory.Iterator(["public", "private", "followers-only"])
 
 
 class CreateActivityFactory(DjangoModelFactory):
+    # Can create activities for notes or actor creation announcements
     class Meta:
         model = CreateActivity
 
-    actor = factory.SubFactory(ActorFactory)
+    actor = factory.SubFactory(ActorFactory, role=Actor.ROLE_SOURCE)
     note = factory.SubFactory(NoteFactory)
     visibility = factory.Iterator(["public", "private", "followers-only"])
 
-    # Helper method to create a CreateActivity for Actor creation
+    # Creates an activity announcing an actor's creation
     @classmethod
     def create_for_actor(cls, actor):
         return cls.create(
@@ -67,38 +96,45 @@ class CreateActivityFactory(DjangoModelFactory):
 
 
 class LikeActivityFactory(DjangoModelFactory):
+    # Only source actors can create like activities
     class Meta:
         model = LikeActivity
 
-    actor = factory.SubFactory(ActorFactory)
-    note = factory.SubFactory(NoteFactory)  # Required for Like activity
+    actor = factory.SubFactory(ActorFactory, role=Actor.ROLE_SOURCE)
+    note = factory.SubFactory(NoteFactory)
     visibility = factory.Iterator(["public", "private", "followers-only"])
+    object_url = None
+    object_data = None
 
 
 class FollowActivityFactory(DjangoModelFactory):
+    # Source actors follow destination actors by default
     class Meta:
         model = FollowActivity
 
-    actor = factory.SubFactory(ActorFactory)
-    target_actor = factory.SubFactory(ActorFactory)  # Required for Follow activity
+    actor = factory.SubFactory(ActorFactory, role=Actor.ROLE_SOURCE)
+    target_actor = factory.SubFactory(ActorFactory, role=Actor.ROLE_DESTINATION)
     visibility = factory.Iterator(["public", "private", "followers-only"])
+    target_actor_url = None
+    target_actor_data = None
 
 
 class PortabilityOutboxFactory(DjangoModelFactory):
+    # Only source actors have outboxes. Creates initial actor creation activity by default.
     class Meta:
         model = PortabilityOutbox
 
-    # Ensure we create a source actor for the outbox
     actor = factory.SubFactory(ActorFactory, role=Actor.ROLE_SOURCE)
 
     @factory.post_generation
     def activities(self, create, extracted, **kwargs):
+        # Adds activities to the outbox after creation
         if not create:
             return
 
         if extracted:
             for activity in extracted:
-                self.add_activity(activity)  # Use the model's add_activity method
+                self.add_activity(activity)
         else:
             # By default, add a Create activity for the Actor
             activity = CreateActivityFactory.create_for_actor(self.actor)

--- a/testbed/core/tests/conftest.py
+++ b/testbed/core/tests/conftest.py
@@ -9,33 +9,70 @@ from testbed.core.factories import (
 )
 from testbed.core.models import Actor
 
+# Creates a user without actors
 @pytest.fixture
 def user():
-    return UserFactory()
+    return UserFactory(with_actors=False)
 
+# Creates a user with both source and destination actors
 @pytest.fixture
-def actor():
-    # Explicitly create a source actor for consistency
-    return ActorFactory(role=Actor.ROLE_SOURCE)
+def user_with_actors():
+    return UserFactory(with_actors=True)
 
+# Creates a pair of actors (source and destination) for a new user
 @pytest.fixture
-def note(actor):
-    return NoteFactory(actor=actor)
+def actor_pair():
+    return ActorFactory.create_pair()
 
+# Returns the source actor from the pair
 @pytest.fixture
-def create_activity(actor, note):
-    return CreateActivityFactory(actor=actor, note=note)
+def source_actor(actor_pair):
+    return actor_pair[0]
 
+# Returns the destination actor from the pair
 @pytest.fixture
-def like_activity(actor, note):
-    return LikeActivityFactory(actor=actor, note=note)
+def destination_actor(actor_pair):
+    return actor_pair[1]
 
+# Creates another source actor for interaction testing
 @pytest.fixture
-def follow_activity(actor):
-    target_actor = ActorFactory()  # Create another actor to follow
-    return FollowActivityFactory(actor=actor, target_actor=target_actor)
+def another_source_actor():
+    return ActorFactory.create_source_actor()
 
+# Creates another destination actor for interaction testing
 @pytest.fixture
-def outbox(actor):
-    # The outbox should be created automatically for source actors
-    return actor.portability_outbox
+def another_destination_actor():
+    return ActorFactory.create_destination_actor()
+
+# Creates a note from a source actor
+@pytest.fixture
+def note(source_actor):
+    return NoteFactory(actor=source_actor)
+
+# Creates a Create activity for a note.
+@pytest.fixture
+def create_activity(source_actor, note):
+    return CreateActivityFactory(actor=source_actor, note=note)
+
+# Creates a Create activity for actor creation
+@pytest.fixture
+def actor_create_activity(source_actor):
+    return CreateActivityFactory.create_for_actor(source_actor)
+
+# Creates a Like activity for a note
+@pytest.fixture
+def like_activity(source_actor, note):
+    return LikeActivityFactory(actor=source_actor, note=note)
+
+# Creates a Follow activity from source to destination actor
+@pytest.fixture
+def follow_activity(source_actor, another_destination_actor):
+    return FollowActivityFactory(
+        actor=source_actor,
+        target_actor=another_destination_actor
+    )
+
+# Returns the outbox of a source actor
+@pytest.fixture
+def outbox(source_actor):
+    return source_actor.portability_outbox

--- a/testbed/core/tests/test_activities.py
+++ b/testbed/core/tests/test_activities.py
@@ -1,56 +1,158 @@
-from testbed.core.models import Actor
+import pytest
+from django.core.exceptions import ValidationError
+from testbed.core.models import Actor, CreateActivity, LikeActivity, FollowActivity
+from testbed.core.factories import (
+    ActorFactory,
+    NoteFactory,
+    CreateActivityFactory,
+    LikeActivityFactory,
+    FollowActivityFactory,
+)
 
-# Test CreateActivity basic properties and relationships
-def test_create_activity(create_activity):
-    assert create_activity.actor is not None
-    assert create_activity.visibility in ["public", "private", "followers-only"]
-    # Test both cases: with note and without note (Actor creation)
-    if create_activity.note:
-        assert str(create_activity) == f"Create by {create_activity.actor.user.username}: {create_activity.note}"
-    else:
-        assert str(create_activity) == f"Create by {create_activity.actor.user.username}: Actor creation"
-
-# Test LikeActivity basic properties and relationships
-def test_like_activity(like_activity):
-    assert like_activity.actor is not None
-    assert like_activity.note is not None  # Required for Like
-    assert like_activity.visibility in ["public", "private", "followers-only"]
-    assert str(like_activity) == f"Like by {like_activity.actor.user.username}: {like_activity.note}"
-
-def test_like_activity_remote_object(like_activity):
-    # Test with remote object instead of local note
-    like_activity.note = None
-    like_activity.object_url = "https://remote.example/notes/123"
-    like_activity.object_data = {"content": "Remote content"}
+# Test Create activity for note creation
+@pytest.mark.django_db
+def test_create_activity_with_note(source_actor):
+    note = NoteFactory(actor=source_actor)
+    activity = CreateActivityFactory(actor=source_actor, note=note)
     
-    assert str(like_activity) == f"Like by {like_activity.actor.user.username}: Remote content..."
-    assert like_activity.object_url == "https://remote.example/notes/123"
-    assert like_activity.object_data["content"] == "Remote content"
+    assert activity.actor.is_source
+    assert activity.note == note
+    assert activity.timestamp is not None
+    assert str(activity) == f"Create by {source_actor.user.username}: {note}"
 
-# Test FollowActivity basic properties and relationships
-def test_follow_activity(follow_activity):
-    assert follow_activity.actor is not None
-    assert follow_activity.target_actor is not None  # Required for Follow
-    assert follow_activity.visibility in ["public", "private", "followers-only"]
-    assert str(follow_activity) == f"Follow by {follow_activity.actor.user.username}: {follow_activity.target_actor.user.username}"
-
-def test_follow_activity_remote_actor(follow_activity):
-    # Test with remote actor instead of local target
-    follow_activity.target_actor = None
-    follow_activity.target_actor_url = "https://remote.example/users/remote_user"
-    follow_activity.target_actor_data = {"preferredUsername": "remote_user"}
+# Test Create activity for actor creation
+@pytest.mark.django_db
+def test_create_activity_for_actor(source_actor):
+    activity = CreateActivityFactory.create_for_actor(source_actor)
     
-    assert str(follow_activity) == f"Follow by {follow_activity.actor.user.username}: remote_user (remote)"
-    assert follow_activity.target_actor_url == "https://remote.example/users/remote_user"
-    assert follow_activity.target_actor_data["preferredUsername"] == "remote_user"
+    assert activity.actor.is_source
+    assert activity.note is None
+    assert activity.timestamp is not None
+    assert str(activity) == f"Create by {source_actor.user.username}: Actor creation"
 
-# Test string representation for all activity types
-def test_activity_str_representation(create_activity, like_activity, follow_activity):
-    # Test that all activities include actor's username in their string representation
-    for activity in [create_activity, like_activity, follow_activity]:
-        assert activity.actor.user.username in str(activity)
+# Test Like activity for local note
+@pytest.mark.django_db
+def test_like_activity_local(source_actor):
+    note = NoteFactory(actor=source_actor)
+    activity = LikeActivityFactory(actor=source_actor, note=note)
+    
+    assert activity.actor.is_source
+    assert activity.note == note
+    assert activity.object_url is None
+    assert activity.object_data is None
+    assert str(activity) == f"Like by {source_actor.user.username}: {note}"
 
-# Test visibility field for all activity types
-def test_activity_visibility(create_activity, like_activity, follow_activity):
-    for activity in [create_activity, like_activity, follow_activity]:
-        assert activity.visibility in ["public", "private", "followers-only"]
+# Test Like activity for remote object
+@pytest.mark.django_db
+def test_like_activity_remote(source_actor):
+    activity = LikeActivityFactory(
+        actor=source_actor,
+        note=None,
+        object_url="https://remote.example/notes/123",
+        object_data={"content": "Remote content"}
+    )
+    
+    assert activity.actor.is_source
+    assert activity.note is None
+    assert activity.object_url == "https://remote.example/notes/123"
+    assert "content" in activity.object_data
+    assert str(activity) == f"Like by {source_actor.user.username}: Remote content..."
+
+# Test Like activity validation rules
+@pytest.mark.django_db
+def test_like_activity_validation():
+    source_actor = ActorFactory.create_source_actor()
+    
+    with pytest.raises(ValidationError):
+        # Neither local note nor remote object
+        LikeActivityFactory(
+            actor=source_actor,
+            note=None,
+            object_url=None,
+            object_data=None
+        ).clean()
+
+# Test Follow activity for local actor
+@pytest.mark.django_db
+def test_follow_activity_local(source_actor, destination_actor):
+    activity = FollowActivityFactory(
+        actor=source_actor,
+        target_actor=destination_actor
+    )
+    
+    assert activity.actor.is_source
+    assert activity.target_actor.is_destination
+    assert activity.target_actor_url is None
+    assert activity.target_actor_data is None
+    assert str(activity) == f"Follow by {source_actor.user.username}: {destination_actor.user.username}"
+
+# Test Follow activity for remote actor
+@pytest.mark.django_db
+def test_follow_activity_remote(source_actor):
+    activity = FollowActivityFactory(
+        actor=source_actor,
+        target_actor=None,
+        target_actor_url="https://remote.example/users/remote_user",
+        target_actor_data={"preferredUsername": "remote_user"}
+    )
+    
+    assert activity.actor.is_source
+    assert activity.target_actor is None
+    assert activity.target_actor_url == "https://remote.example/users/remote_user"
+    assert "preferredUsername" in activity.target_actor_data
+    assert str(activity) == f"Follow by {source_actor.user.username}: remote_user (remote)"
+
+# Test Follow activity validation rules
+@pytest.mark.django_db
+def test_follow_activity_validation():
+    source_actor = ActorFactory.create_source_actor()
+    
+    with pytest.raises(ValidationError):
+        # Neither local target nor remote actor
+        FollowActivityFactory(
+            actor=source_actor,
+            target_actor=None,
+            target_actor_url=None,
+            target_actor_data=None
+        ).clean()
+
+# General Activity Tests
+# Test activities are properly added to outbox
+@pytest.mark.django_db
+def test_activity_outbox_integration(source_actor):
+    outbox = source_actor.portability_outbox
+    initial_count = outbox.activities_create.count()
+
+    # Create different types of activities
+    create_activity = CreateActivityFactory(actor=source_actor)
+    like_activity = LikeActivityFactory(actor=source_actor)
+    follow_activity = FollowActivityFactory(actor=source_actor)
+
+    # Add to outbox
+    outbox.add_activity(create_activity)
+    outbox.add_activity(like_activity)
+    outbox.add_activity(follow_activity)
+
+    # Verify counts
+    assert outbox.activities_create.count() == initial_count + 1
+    assert outbox.activities_like.count() == 1
+    assert outbox.activities_follow.count() == 1
+
+    # Verify activity presence
+    assert create_activity in outbox.activities_create.all()
+    assert like_activity in outbox.activities_like.all()
+    assert follow_activity in outbox.activities_follow.all()
+
+# Test activities maintain proper temporal ordering
+@pytest.mark.django_db
+def test_activity_timestamp_ordering(source_actor):
+    activities = [
+        CreateActivityFactory(actor=source_actor),
+        LikeActivityFactory(actor=source_actor),
+        FollowActivityFactory(actor=source_actor)
+    ]
+    
+    # Verify timestamps exist and are ordered
+    timestamps = [activity.timestamp for activity in activities]
+    assert all(timestamps)
+    assert sorted(timestamps) == timestamps

--- a/testbed/core/tests/test_json_ld.py
+++ b/testbed/core/tests/test_json_ld.py
@@ -9,24 +9,49 @@ from testbed.core.json_ld_builders import (
     build_follow_activity_json_ld,
     build_outbox_json_ld,
 )
-# Test complete flow from API to JSON-LD for Actor
+from testbed.core.factories import (
+    LikeActivityFactory,
+    FollowActivityFactory
+)
+
+# Test complete flow from API to JSON-LD for Source Actor
 @pytest.mark.django_db
-def test_complete_actor_json_ld_flow(actor):
-    # Test direct builder
-    builder_json_ld = build_actor_json_ld(actor)
+def test_source_actor_json_ld_flow(source_actor):
+    # Test JSON-LD generation for source actors
+    builder_json_ld = build_actor_json_ld(source_actor)
     
     # Test API response
     client = APIClient()
-    url = reverse("actor-detail", kwargs={"pk": actor.id})
+    url = reverse("actor-detail", kwargs={"pk": source_actor.id})
     response = client.get(url)
     
     # Both should match
     assert response.data == builder_json_ld
+    assert response.data["type"] == "Person"
+    assert response.data["preferredUsername"] == source_actor.username
+    # assert response.data["role"] == source_actor.role
+
+# Test complete flow from API to JSON-LD for Destination Actor
+@pytest.mark.django_db
+def test_destination_actor_json_ld_flow(destination_actor):
+    # Test JSON-LD generation for destination actors
+    builder_json_ld = build_actor_json_ld(destination_actor)
+    
+    # Test API response
+    client = APIClient()
+    url = reverse("actor-detail", kwargs={"pk": destination_actor.id})
+    response = client.get(url)
+    
+    # Both should match
+    assert response.data == builder_json_ld
+    assert response.data["type"] == "Person"
+    assert response.data["preferredUsername"] == destination_actor.username
+    # assert response.data["role"] == destination_actor.role
 
 # Test complete flow from API to JSON-LD for Outbox
 @pytest.mark.django_db
 def test_complete_outbox_json_ld_flow(outbox):
-    # Test direct builder
+    # Test JSON-LD generation for outboxes
     builder_json_ld = build_outbox_json_ld(outbox)
     
     # Test API response
@@ -40,7 +65,7 @@ def test_complete_outbox_json_ld_flow(outbox):
 # Test that all activity types appear correctly in outbox
 @pytest.mark.django_db
 def test_activity_types_in_outbox(outbox, create_activity, like_activity, follow_activity):
-
+    # Test all activity types in outbox JSON-LD
     outbox.add_activity(create_activity)
     outbox.add_activity(like_activity)
     outbox.add_activity(follow_activity)
@@ -64,9 +89,10 @@ def test_activity_types_in_outbox(outbox, create_activity, like_activity, follow
 
 # Test that JSON-LD structure is consistent across all builders
 @pytest.mark.django_db
-def test_json_ld_consistency(actor, note, create_activity, like_activity, follow_activity):
+def test_json_ld_consistency(source_actor, note, create_activity, like_activity, follow_activity):
+    # Test JSON-LD structure consistency across all builders
     builders_and_objects = [
-        (build_actor_json_ld, actor),
+        (build_actor_json_ld, source_actor),
         (build_note_json_ld, note),
         (build_create_activity_json_ld, create_activity),
         (build_like_activity_json_ld, like_activity),
@@ -78,3 +104,30 @@ def test_json_ld_consistency(actor, note, create_activity, like_activity, follow
         assert "@context" in json_ld
         assert "type" in json_ld
         assert "id" in json_ld
+
+# Test JSON-LD for remote activities
+@pytest.mark.django_db
+def test_remote_activity_json_ld(source_actor):
+    # Test JSON-LD generation for activities with remote objects
+    # Create activities with remote objects
+    like_activity = LikeActivityFactory(
+        actor=source_actor,
+        note=None,
+        object_url="https://remote.example/notes/123",
+        object_data={"content": "Remote content"}
+    )
+    
+    follow_activity = FollowActivityFactory(
+        actor=source_actor,
+        target_actor=None,
+        target_actor_url="https://remote.example/users/remote_user",
+        target_actor_data={"preferredUsername": "remote_user"}
+    )
+
+    # Test JSON-LD generation
+    like_json_ld = build_like_activity_json_ld(like_activity)
+    follow_json_ld = build_follow_activity_json_ld(follow_activity)
+
+    # Verify remote object structure
+    assert like_json_ld["object"]["id"] == "https://remote.example/notes/123"
+    assert follow_json_ld["object"]["id"] == "https://remote.example/users/remote_user"

--- a/testbed/core/tests/test_json_ld_builders.py
+++ b/testbed/core/tests/test_json_ld_builders.py
@@ -1,130 +1,155 @@
 import pytest
-from testbed.core.factories import (
-    CreateActivityFactory,
-    LikeActivityFactory,
-    FollowActivityFactory
-)
 from testbed.core.json_ld_builders import (
     build_actor_json_ld,
     build_note_json_ld,
     build_create_activity_json_ld,
     build_like_activity_json_ld,
     build_follow_activity_json_ld,
-    build_outbox_json_ld,
+    build_outbox_json_ld
 )
 from testbed.core.json_ld_utils import (
-    build_actor_context,
     build_basic_context,
+    build_actor_context,
     build_actor_id,
     build_note_id,
     build_activity_id,
-    build_outbox_id,
+    build_outbox_id
+)
+from testbed.core.factories import (
+    LikeActivityFactory,
+    FollowActivityFactory,
+    CreateActivityFactory,
+    NoteFactory
 )
 
-# Test Actor JSON-LD builder
-def test_build_actor_json_ld(actor):
-    json_ld = build_actor_json_ld(actor)
+# Test building JSON-LD for a source actor
+@pytest.mark.django_db
+def test_build_actor_json_ld(source_actor):
+    json_ld = build_actor_json_ld(source_actor)
     
     assert json_ld["@context"] == build_actor_context()
     assert json_ld["type"] == "Person"
-    assert json_ld["id"] == build_actor_id(actor.id)
-    assert json_ld["preferredUsername"] == actor.username
-    assert json_ld["name"] == actor.username
+    assert json_ld["id"] == build_actor_id(source_actor.id)
+    assert json_ld["preferredUsername"] == source_actor.username
+    assert json_ld["name"] == source_actor.username
     assert isinstance(json_ld["previously"], list)
 
-
+# Test building JSON-LD for a note"
+@pytest.mark.django_db
 def test_build_note_json_ld(note):
     json_ld = build_note_json_ld(note)
-
+    
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "Note"
     assert json_ld["id"] == build_note_id(note.id)
     assert json_ld["actor"] == build_actor_id(note.actor.id)
     assert json_ld["content"] == note.content
-    assert json_ld["published"] == note.published.isoformat()
     assert json_ld["visibility"] == note.visibility
 
-
-def test_build_create_activity_json_ld_with_note(create_activity):
-    json_ld = build_create_activity_json_ld(create_activity)
+# Test building JSON-LD for note creation activity
+@pytest.mark.django_db
+def test_build_create_activity_json_ld_note(source_actor):
+    note = NoteFactory(actor=source_actor)
+    activity = CreateActivityFactory(actor=source_actor, note=note)
+    json_ld = build_create_activity_json_ld(activity)
     
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "Create"
-    assert json_ld["id"] == build_activity_id(create_activity.id)
-    assert json_ld["actor"] == build_actor_id(create_activity.actor.id)
-    assert json_ld["published"] == create_activity.timestamp.isoformat()
-    assert json_ld["visibility"] == create_activity.visibility
+    assert json_ld["id"] == build_activity_id(activity.id)
+    assert json_ld["actor"] == build_actor_id(source_actor.id)
     assert json_ld["object"]["type"] == "Note"
+    assert json_ld["object"]["id"] == build_note_id(note.id)
 
-# Test Create Activity JSON-LD builder for actor creation
-def test_build_create_activity_json_ld_actor_creation(actor):
-    create_activity = CreateActivityFactory(
-        actor=actor,
-        note=None
-    )
-    json_ld = build_create_activity_json_ld(create_activity)
+# Test building JSON-LD for actor creation activity
+@pytest.mark.django_db
+def test_build_create_activity_json_ld_actor_creation(source_actor):
+    activity = CreateActivityFactory.create_for_actor(source_actor)
+    json_ld = build_create_activity_json_ld(activity)
     
+    assert json_ld["@context"] == build_basic_context()
+    assert json_ld["type"] == "Create"
+    assert json_ld["id"] == build_activity_id(activity.id)
+    assert json_ld["actor"] == build_actor_id(source_actor.id)
     assert json_ld["object"]["type"] == "Person"
-    assert json_ld["object"]["id"] == build_actor_id(actor.id)
+    assert json_ld["object"]["id"] == build_actor_id(source_actor.id)
 
-# Test Like Activity JSON-LD builder with local note
-def test_build_like_activity_json_ld_local(like_activity):
-    json_ld = build_like_activity_json_ld(like_activity)
+# Test building JSON-LD for local like activity
+@pytest.mark.django_db
+def test_build_like_activity_json_ld_local(source_actor):
+    note = NoteFactory(actor=source_actor)
+    activity = LikeActivityFactory(actor=source_actor, note=note)
+    json_ld = build_like_activity_json_ld(activity)
     
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "Like"
-    assert json_ld["id"] == build_activity_id(like_activity.id)
-    assert json_ld["actor"] == build_actor_id(like_activity.actor.id)
+    assert json_ld["id"] == build_activity_id(activity.id)
+    assert json_ld["actor"] == build_actor_id(source_actor.id)
     assert json_ld["object"]["type"] == "Note"
+    assert json_ld["object"]["id"] == build_note_id(note.id)
 
-# Test Like Activity JSON-LD builder with remote object
-def test_build_like_activity_json_ld_remote(actor):
-    remote_data = {
-        "type": "Note",
-        "content": "Remote content"
-    }
-    like_activity = LikeActivityFactory(
-        actor=actor,
+# Test building JSON-LD for remote like activity
+@pytest.mark.django_db
+def test_build_like_activity_json_ld_remote(source_actor):
+    activity = LikeActivityFactory(
+        actor=source_actor,
         note=None,
         object_url="https://remote.example/notes/123",
-        object_data=remote_data
+        object_data={"content": "Remote content"}
     )
     
-    json_ld = build_like_activity_json_ld(like_activity)
+    json_ld = build_like_activity_json_ld(activity)
+    assert json_ld["@context"] == build_basic_context()
+    assert json_ld["type"] == "Like"
+    assert json_ld["id"] == build_activity_id(activity.id)
+    assert json_ld["actor"] == build_actor_id(source_actor.id)
     assert json_ld["object"]["id"] == "https://remote.example/notes/123"
     assert json_ld["object"]["content"] == "Remote content"
 
-# Test Follow Activity JSON-LD builder with local actor
-def test_build_follow_activity_json_ld_local(follow_activity):
-    json_ld = build_follow_activity_json_ld(follow_activity)
-    
-    assert json_ld["@context"] == build_basic_context()
-    assert json_ld["type"] == "Follow"
-    assert json_ld["id"] == build_activity_id(follow_activity.id)
-    assert json_ld["actor"] == build_actor_id(follow_activity.actor.id)
-    assert json_ld["object"]["type"] == "Person"
-
-# Test Follow Activity JSON-LD builder with remote actor
-def test_build_follow_activity_json_ld_remote(actor):
-    remote_data = {
-        "type": "Person",
-        "preferredUsername": "remote_user"
-    }
-    follow_activity = FollowActivityFactory(
-        actor=actor,
-        target_actor=None,
-        target_actor_url="https://remote.example/users/remote_user",
-        target_actor_data=remote_data
+# Test building JSON-LD for local follow activity
+@pytest.mark.django_db
+def test_build_follow_activity_json_ld_local(source_actor, destination_actor):
+    activity = FollowActivityFactory(
+        actor=source_actor,
+        target_actor=destination_actor
     )
     
-    json_ld = build_follow_activity_json_ld(follow_activity)
+    json_ld = build_follow_activity_json_ld(activity)
+    assert json_ld["@context"] == build_basic_context()
+    assert json_ld["type"] == "Follow"
+    assert json_ld["id"] == build_activity_id(activity.id)
+    assert json_ld["actor"] == build_actor_id(source_actor.id)
+    assert json_ld["object"]["type"] == "Person"
+    assert json_ld["object"]["id"] == build_actor_id(destination_actor.id)
+
+# Test building JSON-LD for remote follow activity
+@pytest.mark.django_db
+def test_build_follow_activity_json_ld_remote(source_actor):
+    activity = FollowActivityFactory(
+        actor=source_actor,
+        target_actor=None,
+        target_actor_url="https://remote.example/users/remote_user",
+        target_actor_data={"preferredUsername": "remote_user"}
+    )
+    
+    json_ld = build_follow_activity_json_ld(activity)
+    assert json_ld["@context"] == build_basic_context()
+    assert json_ld["type"] == "Follow"
+    assert json_ld["id"] == build_activity_id(activity.id)
+    assert json_ld["actor"] == build_actor_id(source_actor.id)
     assert json_ld["object"]["id"] == "https://remote.example/users/remote_user"
     assert json_ld["object"]["preferredUsername"] == "remote_user"
 
 # Test Outbox JSON-LD builder with multiple activities
+@pytest.mark.django_db
 def test_build_outbox_json_ld(outbox, create_activity, like_activity, follow_activity):
+    # Add activities to outbox
+    outbox.add_activity(create_activity)
+    outbox.add_activity(like_activity)
+    outbox.add_activity(follow_activity)
+    
     json_ld = build_outbox_json_ld(outbox)
     
+    # Check outbox structure
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "OrderedCollection"
     assert json_ld["id"] == build_outbox_id(outbox.actor.id)
@@ -139,3 +164,9 @@ def test_build_outbox_json_ld(outbox, create_activity, like_activity, follow_act
         assert "actor" in item
         assert "published" in item
         assert "visibility" in item
+    
+    # Verify activity types are present
+    activity_types = {item["type"] for item in json_ld["items"]}
+    assert "Create" in activity_types
+    assert "Like" in activity_types
+    assert "Follow" in activity_types

--- a/testbed/core/tests/test_urls.py
+++ b/testbed/core/tests/test_urls.py
@@ -1,29 +1,49 @@
-from django.urls import resolve, reverse
+from django.urls import reverse, resolve
 from django.urls.exceptions import Resolver404
 import pytest
 
-
+# Test actor detail URL patterns
 def test_actor_detail_url():
+    # Test URL generation
     url = reverse('actor-detail', kwargs={'pk': 1})
     assert url == '/api/actors/1/'
     
+    # Test URL resolution
     resolver = resolve("/api/actors/1/")
     assert resolver.view_name == "actor-detail"
-    assert resolver.kwargs['pk'] == 1  # Compare as integer
+    assert resolver.kwargs['pk'] == 1  # URL parameters are integers
 
-
+# Test outbox detail URL patterns
 def test_outbox_detail_url():
+    # Test URL generation
     url = reverse('actor-outbox', kwargs={'pk': 1})
     assert url == '/api/actors/1/outbox/'
     
+    # Test URL resolution
     resolver = resolve("/api/actors/1/outbox/")
     assert resolver.view_name == "actor-outbox"
-    assert resolver.kwargs['pk'] == 1  # Compare as integer
+    assert resolver.kwargs['pk'] == 1  # URL parameters are integers
 
+# Test that invalid URLs don't resolve
+def test_invalid_urls():
+    invalid_urls = [
+        "/api/actors/",
+        "/api/actors/1/invalid/",
+        "/api/actors/abc/",  # Non-numeric ID
+        "/api/actors//outbox/",  # Missing ID
+    ]
+    
+    for url in invalid_urls:
+        with pytest.raises(Resolver404):
+            resolve(url)
 
-def test_url_patterns():
-    # Test invalid URLs return 404
-    with pytest.raises(Resolver404):
-        resolve("/api/actors/")
-    with pytest.raises(Resolver404):
-        resolve("/api/actors/1/invalid/")
+# Test URL reverse lookup with different inputs
+def test_url_reversing():
+    # Test with integer ID
+    assert reverse('actor-detail', kwargs={'pk': 1}) == '/api/actors/1/'
+    
+    # Test with string ID (should work the same)
+    assert reverse('actor-detail', kwargs={'pk': '1'}) == '/api/actors/1/'
+    
+    # Test outbox URLs
+    assert reverse('actor-outbox', kwargs={'pk': 1}) == '/api/actors/1/outbox/'


### PR DESCRIPTION
This PR updates how we handle actors in our tests. I've added new factory methods that make it clear whether we're working with source or destination actors, and you can create them either one at a time or in pairs.

The factory setup is now more straightforward - UserFactory has a new `with_actors` option that controls actor creation, and ActorFactory has dedicated methods for creating different types of actors. This matches how actors work in our actual system.

I also updated our test suite to use these new factories better. Tests now clearly specify what kind of actor they need, and activity factories make sure activities come from the right type of actor. I made sure everything works for both local and remote scenarios.

The test structure remains familiar, but now works better with the new factories.

This should be our final major update to the testing setup for now. We've built a solid foundation for testing our dual-actor system that will support our future development needs.