### PR TITLE
Add actors to homepage

### DIFF
--- a/static/scss/index.scss
+++ b/static/scss/index.scss
@@ -1,0 +1,12 @@
+.index {
+  h3 {
+    margin: 10px 0;
+  }
+
+  .actor {
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    padding: 10px;
+    background: #f5f5f5;
+  }
+}

--- a/static/scss/site.scss
+++ b/static/scss/site.scss
@@ -1,3 +1,4 @@
 @import "reset";
 @import "_base";
+@import "index";
 

--- a/testbed/core/templates/index.html
+++ b/testbed/core/templates/index.html
@@ -1,19 +1,49 @@
 {% extends "_base.html" %}
-
+ 
 {% block content %}
-<main>
+<main class="index">
   <h1>ActivityPub Account Portability Testbed</h1>
   <br />
+  {% if user.is_authenticated %}
+
+    {% if source_actor or destination_actor %}
+
+    <p>
+      Here are the ActivityPub Actors available for you to test LOLA account portability with:
+    </p>
+    {% if source_actor %}
+    <h3>Source</h3>
+    <div class="actor">
+      <div>Username: {{ source_actor.username }}</div>
+      <div><a href="{% url 'actor-detail' pk=source_actor.pk %}">Details</a></div>
+      <div><a href="{% url 'actor-outbox' pk=source_actor.pk %}">Outbox</a></div>
+      </div>
+    {% endif %}
+    {% if destination_actor %}
+    <h3>Destination</h3>
+    <div class="actor">
+      <div>Username: {{ destination_actor.username }}</div>
+      <div class="actor__links">
+      <a href="{% url 'actor-detail' pk=destination_actor.pk %}">Details</a>
+    </div>
+    {% endif %}
+  
+    {% else %}
+    <p>There are no ActivityPub Actors available for testing yet.</p>
+    {% endif %}
+
+  {% else %}
   <p>
     The <a href="https://www.w3.org/TR/activitypub/">ActivityPub</a> account portability testbed is an implementation of <a href="https://swicg.github.io/activitypub-data-portability/lola.html">LOLA</a>, a proposal for an interoperable approach to moving accounts between ActivityPub servers.  The testbed implements LOLA as a source server currently, and we have plans to implement LOLA as a destination as well.
   </p>
   <br />
   <p>
-    If you are building a LOLA implementation, register for a test account here (coming soon).  The account will be populated with test data including posts, follows and item history.  Use this account to test moving an ActivityPub Actor’s full account to your site.
+    If you are building a LOLA implementation, register for a test account <a href="{% url 'account_signup' %}">here</a>.  The account will be populated with test data including posts, follows and item history.  Use this account to test moving an ActivityPub Actor’s full account to your site.
   </p>
   <br />
   <p>
     Accounts on this site are not full ActivityPub accounts in that they are not shared to the Fediverse or truly federated with other ActivityPubservers.
   </p>
+  {% endif %}
 </main>
 {% endblock %}

--- a/testbed/core/views.py
+++ b/testbed/core/views.py
@@ -43,4 +43,11 @@ def report_activity(request):
 
 
 def index(request):
-    return render(request, "index.html")
+    if not request.user.is_authenticated:
+        return render(request, "index.html")
+
+    user_actors = Actor.objects.filter(user=request.user)
+    return render(request, "index.html", {
+        'source_actor': user_actors.filter(role=Actor.ROLE_SOURCE).first(),
+        'destination_actor': user_actors.filter(role=Actor.ROLE_DESTINATION).first()
+    })


### PR DESCRIPTION
Closes #108.

Adds source and destination actors to homepage, if available.

![Screenshot From 2025-06-03 16-28-03](https://github.com/user-attachments/assets/5c4b64c8-f7b7-40fc-be4d-2bba308b738a)
![Screenshot From 2025-06-03 16-29-17](https://github.com/user-attachments/assets/0165b649-1ae4-45dc-8c2f-3372598ff7ed)
