### PR TITLE
Clean up OAuth test suite with factories and helper methods

### DIFF
--- a/testbed/core/json_ld_builders.py
+++ b/testbed/core/json_ld_builders.py
@@ -3,8 +3,8 @@ from .json_ld_utils import (build_basic_context,
                             build_actor_id,
                             build_activity_id,
                             build_note_id,
-                            build_outbox_id,
-                            build_oauth_endpoint_url)
+                            build_outbox_id)
+from .utils.oauth_utils import build_oauth_endpoint_url
 from .models import CreateActivity, LikeActivity, FollowActivity
 
 def build_actor_json_ld(actor, auth_context=None):

--- a/testbed/core/json_ld_utils.py
+++ b/testbed/core/json_ld_utils.py
@@ -27,9 +27,3 @@ def build_note_id(note_id):
 
 def build_outbox_id(actor_id):
     return f"https://example.com/actors/{actor_id}/outbox"
-
-# Build OAuth authorization endpoint URL for LOLA discovery
-def build_oauth_endpoint_url(request):
-    scheme = request.scheme
-    host = request.get_host()
-    return f"{scheme}://{host}/oauth/authorize/"

--- a/testbed/core/tests/test_api.py
+++ b/testbed/core/tests/test_api.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from oauth2_provider.models import Application, AccessToken
 from testbed.core.models import Actor
-from testbed.core.factories import ActorFactory
+from testbed.core.factories import ActorFactory, ApplicationFactory, AccessTokenFactory
 from testbed.core.tests.conftest import create_isolated_actor
 from testbed.core.json_ld_utils import (
     build_basic_context,
@@ -78,50 +78,44 @@ def test_outbox_not_found():
 Tests the complete request-response cycle with different authentication states
 to verify that endpoints properly serve enhanced data for LOLA-authenticated requests.
 """
-class TestLOLAAuthenticationAPI:    
+class TestLOLAAuthenticationAPI:
+    # Constants for OAuth scopes
+    LOLA_SCOPE = 'activitypub_account_portability read write'
+    BASIC_SCOPE = 'read write'
+    
+    # Helper methods for repeated assertions
 
-    # Create OAuth application for testing
-    @pytest.fixture
-    def oauth_application(self, db):
-        return Application.objects.create(
-            name="LOLA Test Application",
-            client_type=Application.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
-            redirect_uris="http://localhost:8000/callback/",
-        )
-    
-    # Create user for OAuth token testing
-    @pytest.fixture
-    def authenticated_user(self, db):
-        return User.objects.create_user(
-            username='lola_test_user',
-            email='lola@test.example.com',
-            password='test123password'
-        )
-    
-    # Create access token with LOLA portability scope
-    @pytest.fixture
-    def lola_token(self, oauth_application, authenticated_user):
-        from datetime import datetime, timezone, timedelta
-        return AccessToken.objects.create(
-            user=authenticated_user,
-            application=oauth_application,
-            token='lola-portability-token-12345',
-            scope='activitypub_account_portability read write',
-            expires=datetime.now(timezone.utc) + timedelta(hours=1)  # Expires in 1 hour
-        )
-    
-    # Create access token without LOLA portability scope
-    @pytest.fixture
-    def basic_token(self, oauth_application, authenticated_user):
-        from datetime import datetime, timezone, timedelta
-        return AccessToken.objects.create(
-            user=authenticated_user,
-            application=oauth_application,
-            token='basic-oauth-token-67890',
-            scope='read write',
-            expires=datetime.now(timezone.utc) + timedelta(hours=1)  # Expires in 1 hour
-        )
+    # Helper to verify standard ActivityPub fields
+    def assert_basic_activitypub_structure(self, data, actor):
+        assert data["@context"] == build_actor_context()
+        assert data["type"] == "Person"
+        assert data["id"] == build_actor_id(actor.id)
+        assert data["preferredUsername"] == actor.username
+        
+    # Helper to verify LOLA fields are absent
+    def assert_no_lola_fields(self, data):
+        lola_fields = ["accountPortabilityOauth", "content", "blocked", "migration"]
+        for field in lola_fields:
+            assert field not in data
+            
+    # Helper to verify LOLA fields are present and properly formatted        
+    def assert_has_lola_fields(self, data, actor):
+        assert "accountPortabilityOauth" in data
+        assert "content" in data
+        assert "blocked" in data
+        assert "migration" in data
+        
+        # Verify LOLA URLs are properly formatted
+        assert data["accountPortabilityOauth"].endswith("/oauth/authorize/")
+        assert data["content"].endswith(f"/actors/{actor.id}/content")
+        assert data["blocked"].endswith(f"/actors/{actor.id}/blocked")
+        assert data["migration"].endswith(f"/actors/{actor.id}/outbox")
+        
+    # Helper to create authenticated client    
+    def get_authenticated_client(self, token):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f'Bearer {token.token}')
+        return client
     
     # Test that unauthenticated requests return basic ActivityPub data only
     @pytest.mark.django_db
@@ -135,24 +129,16 @@ class TestLOLAAuthenticationAPI:
         assert response.status_code == status.HTTP_200_OK
         
         data = response.data
-        # Should have standard ActivityPub fields
-        assert data["@context"] == build_actor_context()
-        assert data["type"] == "Person"
-        assert data["id"] == build_actor_id(actor.id)
-        assert data["preferredUsername"] == actor.username
-        
-        # Should NOT have LOLA-specific fields
-        assert "accountPortabilityOauth" not in data
-        assert "content" not in data
-        assert "blocked" not in data
-        assert "migration" not in data
+        # Use helper methods for assertions
+        self.assert_basic_activitypub_structure(data, actor)
+        self.assert_no_lola_fields(data)
     
     # Test that LOLA-authenticated requests return enhanced data with collection URLs
     @pytest.mark.django_db
-    def test_actor_detail_with_lola_scope_returns_enhanced_data(self, lola_token):
+    def test_actor_detail_with_lola_scope_returns_enhanced_data(self):
         actor = create_isolated_actor("lola_enhanced_test")
-        client = APIClient()
-        client.credentials(HTTP_AUTHORIZATION=f'Bearer {lola_token.token}')
+        lola_token = AccessTokenFactory(lola_scope=True)
+        client = self.get_authenticated_client(lola_token)
         
         response = client.get(reverse("actor-detail", kwargs={"pk": actor.id}))
         
@@ -160,30 +146,16 @@ class TestLOLAAuthenticationAPI:
         assert response.status_code == status.HTTP_200_OK
         
         data = response.data
-        # Should have standard ActivityPub fields
-        assert data["@context"] == build_actor_context()
-        assert data["type"] == "Person"
-        assert data["id"] == build_actor_id(actor.id)
-        assert data["preferredUsername"] == actor.username
-        
-        # Should HAVE LOLA-specific collection URLs
-        assert "accountPortabilityOauth" in data
-        assert "content" in data
-        assert "blocked" in data
-        assert "migration" in data
-        
-        # Verify LOLA URLs are properly formatted
-        assert data["accountPortabilityOauth"].endswith("/oauth/authorize/")
-        assert data["content"].endswith(f"/actors/{actor.id}/content")
-        assert data["blocked"].endswith(f"/actors/{actor.id}/blocked")
-        assert data["migration"].endswith(f"/actors/{actor.id}/outbox")
+        # Use helper methods for assertions
+        self.assert_basic_activitypub_structure(data, actor)
+        self.assert_has_lola_fields(data, actor)
     
     # Test that authenticated requests without LOLA scope return basic data
     @pytest.mark.django_db
-    def test_actor_detail_with_basic_token_returns_basic_data(self, basic_token):
+    def test_actor_detail_with_basic_token_returns_basic_data(self):
         actor = create_isolated_actor("basic_token_test")
-        client = APIClient()
-        client.credentials(HTTP_AUTHORIZATION=f'Bearer {basic_token.token}')
+        basic_token = AccessTokenFactory(scope=self.BASIC_SCOPE)
+        client = self.get_authenticated_client(basic_token)
         
         response = client.get(reverse("actor-detail", kwargs={"pk": actor.id}))
         
@@ -191,20 +163,15 @@ class TestLOLAAuthenticationAPI:
         assert response.status_code == status.HTTP_200_OK
         
         data = response.data
-        # Should have standard fields
-        assert data["type"] == "Person"
-        assert data["preferredUsername"] == actor.username
-        
-        # Should NOT have LOLA fields (lacks portability scope)
-        assert "accountPortabilityOauth" not in data
-        assert "content" not in data
-        assert "blocked" not in data
-        assert "migration" not in data
+        # Use helper methods for assertions
+        self.assert_basic_activitypub_structure(data, actor)
+        self.assert_no_lola_fields(data)
     
     # Test that URL parameter authentication works for LOLA testing
     @pytest.mark.django_db
-    def test_actor_detail_url_parameter_authentication(self, lola_token):
+    def test_actor_detail_url_parameter_authentication(self):
         actor = create_isolated_actor("url_param_test")
+        lola_token = AccessTokenFactory(lola_scope=True)
         client = APIClient()
         
         # Use auth_token URL parameter instead of Authorization header
@@ -215,14 +182,13 @@ class TestLOLAAuthenticationAPI:
         
         data = response.data
         # Should have LOLA fields (proves URL parameter auth worked)
-        assert "accountPortabilityOauth" in data
-        assert "content" in data
-        assert "blocked" in data
+        self.assert_has_lola_fields(data, actor)
     
     # Test that outbox shows different content based on authentication
     @pytest.mark.django_db
-    def test_outbox_content_filtering_by_authentication(self, lola_token):
+    def test_outbox_content_filtering_by_authentication(self):
         actor = create_isolated_actor("outbox_filtering_test")
+        lola_token = AccessTokenFactory(lola_scope=True)
         client = APIClient()
         
         # Test unauthenticated outbox (public activities only)
@@ -256,8 +222,9 @@ class TestLOLAAuthenticationAPI:
     
     # Test that demonstrates clear differences between public and LOLA responses
     @pytest.mark.django_db
-    def test_side_by_side_authentication_comparison(self, lola_token):
+    def test_side_by_side_authentication_comparison(self):
         actor = create_isolated_actor("comparison_test")
+        lola_token = AccessTokenFactory(lola_scope=True)
         
         # Public request
         public_client = APIClient()
@@ -265,8 +232,7 @@ class TestLOLAAuthenticationAPI:
         public_data = public_response.data
         
         # LOLA request
-        lola_client = APIClient()
-        lola_client.credentials(HTTP_AUTHORIZATION=f'Bearer {lola_token.token}')
+        lola_client = self.get_authenticated_client(lola_token)
         lola_response = lola_client.get(reverse("actor-detail", kwargs={"pk": actor.id}))
         lola_data = lola_response.data
         
@@ -307,35 +273,32 @@ class TestLOLAAuthenticationAPI:
         assert "blocked" not in data
     
     # Test graceful handling of malformed authorization headers
+    @pytest.mark.parametrize("malformed_header", [
+        "Bearer",  # Missing token
+        "Basic invalid-format",  # Wrong auth type
+        "Bearer  ",  # Empty token
+        "InvalidFormat token",  # Malformed header
+    ])
     @pytest.mark.django_db
-    def test_malformed_authorization_header_handling(self):
+    def test_malformed_authorization_header_handling(self, malformed_header):
         actor = create_isolated_actor("malformed_header_test")
         client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=malformed_header)
         
-        test_cases = [
-            "Bearer",  # Missing token
-            "Basic invalid-format",  # Wrong auth type
-            "Bearer  ",  # Empty token
-            "InvalidFormat token",  # Malformed header
-        ]
+        response = client.get(reverse("actor-detail", kwargs={"pk": actor.id}))
         
-        for malformed_header in test_cases:
-            client.credentials(HTTP_AUTHORIZATION=malformed_header)
-            response = client.get(reverse("actor-detail", kwargs={"pk": actor.id}))
-            
-            # Should succeed with public data for all malformed cases
-            assert response.status_code == status.HTTP_200_OK
-            data = response.data
-            assert data["type"] == "Person"
-            # Should NOT have LOLA fields
-            assert "accountPortabilityOauth" not in data
+        # Should succeed with public data for all malformed cases
+        assert response.status_code == status.HTTP_200_OK
+        data = response.data
+        self.assert_basic_activitypub_structure(data, actor)
+        self.assert_no_lola_fields(data)
     
     # Test that content-type headers are set correctly for API responses
     @pytest.mark.django_db
-    def test_content_type_headers_set_correctly(self, lola_token):
+    def test_content_type_headers_set_correctly(self):
         actor = create_isolated_actor("content_type_test")
-        client = APIClient()
-        client.credentials(HTTP_AUTHORIZATION=f'Bearer {lola_token.token}')
+        lola_token = AccessTokenFactory(lola_scope=True)
+        client = self.get_authenticated_client(lola_token)
         
         # Request with format=json 
         response = client.get(reverse("actor-detail", kwargs={"pk": actor.id}), {"format": "json"})

--- a/testbed/core/utils/oauth_utils.py
+++ b/testbed/core/utils/oauth_utils.py
@@ -176,3 +176,23 @@ def validate_state_from_session(request, state):
         logger.warning("OAuth state parameter validation failed")
         
     return is_valid
+
+# OAuth Endpoint URL Construction
+def build_oauth_endpoint_url(request):
+    """
+    Build OAuth authorization endpoint URL for LOLA discovery.
+    
+    This function constructs the OAuth authorization endpoint URL that will be
+    included in ActivityPub Actor responses for LOLA account portability.
+    The URL allows other ActivityPub services to discover where users can
+    authorize access for account migration.
+    
+    Args:
+        request: The HTTP request object containing scheme and host information
+        
+    Returns:
+        String containing the fully qualified OAuth authorization endpoint URL
+    """
+    scheme = request.scheme
+    host = request.get_host()
+    return f"{scheme}://{host}/oauth/authorize/"


### PR DESCRIPTION
**Depends on #162 . Will retarget to main after PR1 merges.**

This PR is stacked on #162 (docs/update-oauth-documentation). Please review #162 first. The base of this PR is set to docs/update-oauth-documentation so the diff only shows commits from iterate/feedback-from-pr-161. After #162  merges, I will retarget the PR to main.

---

This PR iterates over feedback from PR #161.

- Replaced pytest fixtures with factory_boy factories (`ApplicationFactory`, `AccessTokenFactory`)
- Added helper methods to eliminate repetitive test assertions  
- Converted malformed header test from loop to pytest parametrization
- Added constants for OAuth scopes to avoid magic strings
- Test are now cleaner and easier to maintain