### PR TITLE
Address PRs review comments - security, terminology, and tests refactoring

### DIFF
--- a/testbed/core/json_ld_utils.py
+++ b/testbed/core/json_ld_utils.py
@@ -13,44 +13,27 @@ def build_actor_context():
         JsonLDContext.LOLA
     ]
 
-def build_id_url(type_name, obj_id, request=None):
+def build_id_url(type_name, obj_id, request):
     """
     Build dynamic URLs based on the current request.
     This ensures URLs work in development, production, and any deployment environment.
     """
-    if request:
-        base_url = f"{request.scheme}://{request.get_host()}"
-        return f"{base_url}/api/{type_name}/{obj_id}"
-    else:
-        # Fallback for cases where request is not available (testing, etc.)
-        return f"https://example.com/{type_name}/{obj_id}"
+    base_url = f"{request.scheme}://{request.get_host()}"
+    return f"{base_url}/api/{type_name}/{obj_id}"
 
-def build_actor_id(actor_id, request=None):
-    if request:
-        base_url = f"{request.scheme}://{request.get_host()}"
-        return f"{base_url}/api/actors/{actor_id}"
-    else:
-        return f"https://example.com/actors/{actor_id}"
+def build_actor_id(actor_id, request):
+    base_url = f"{request.scheme}://{request.get_host()}"
+    return f"{base_url}/api/actors/{actor_id}"
 
-def build_activity_id(activity_id, request=None):
-    if request:
-        base_url = f"{request.scheme}://{request.get_host()}"
-        return f"{base_url}/api/activities/{activity_id}"
-    else:
-        return f"https://example.com/activities/{activity_id}"
+def build_activity_id(activity_id, request):
+    base_url = f"{request.scheme}://{request.get_host()}"
+    return f"{base_url}/api/activities/{activity_id}"
 
-def build_note_id(note_id, request=None):
-    if request:
-        base_url = f"{request.scheme}://{request.get_host()}"
-        return f"{base_url}/api/notes/{note_id}"
-    else:
-        return f"https://example.com/notes/{note_id}"
+def build_note_id(note_id, request):
+    base_url = f"{request.scheme}://{request.get_host()}"
+    return f"{base_url}/api/notes/{note_id}"
 
-# Build outbox URL with dynamic base URL
-def build_outbox_id(actor_id, request=None):
-    if request:
-        base_url = f"{request.scheme}://{request.get_host()}"
-        return f"{base_url}/api/actors/{actor_id}/outbox"
-    else:
-        # Fallback for cases where request is not available
-        return f"https://example.com/actors/{actor_id}/outbox"
+def build_outbox_id(actor_id, request):
+    # Build outbox URL with dynamic base URL.
+    base_url = f"{request.scheme}://{request.get_host()}"
+    return f"{base_url}/api/actors/{actor_id}/outbox"

--- a/testbed/core/tests/conftest.py
+++ b/testbed/core/tests/conftest.py
@@ -164,3 +164,87 @@ def populated_source_actor():
     )
     
     return source_actor
+
+
+# Provide consistent request objects and authentication contexts for JSON-LD builder testing
+
+@pytest.fixture
+def mock_request():
+    """
+    Create a mock request object for testing JSON-LD URL generation.
+    
+    This fixture provides a consistent request object that can be used across
+    all test files for building URLs in JSON-LD responses.
+    
+    Returns:
+        Mock request object with proper META data for URL building
+    """
+    from django.test import RequestFactory
+    
+    factory = RequestFactory()
+    request = factory.get('/api/actors/')
+    request.META['HTTP_HOST'] = 'testserver'
+    
+    return request
+
+@pytest.fixture
+def basic_auth_context(mock_request):
+    """
+    Auth context for unauthenticated requests (basic ActivityPub).
+    
+    This fixture provides the authentication context used for public/unauthenticated
+    requests that should receive basic ActivityPub data without LOLA enhancements.
+    
+    Args:
+        mock_request: Automatically injected mock request fixture
+        
+    Returns:
+        Dict with authentication context for basic ActivityPub responses
+    """
+    return {
+        'is_authenticated': False,
+        'has_portability_scope': False,
+        'request': mock_request
+    }
+
+@pytest.fixture
+def lola_auth_context(mock_request):
+    """
+    Auth context for LOLA authenticated requests (enhanced data).
+    
+    This fixture provides the authentication context used for requests with
+    proper LOLA portability scope that should receive enhanced data including
+    discovery fields and private content.
+    
+    Args:
+        mock_request: Automatically injected mock request fixture
+        
+    Returns:
+        Dict with authentication context for LOLA enhanced responses
+    """
+    return {
+        'is_authenticated': True,
+        'has_portability_scope': True,
+        'request': mock_request
+    }
+
+@pytest.fixture
+def oauth_auth_context(mock_request):
+    """
+    Auth context for OAuth authenticated requests without portability scope.
+    
+    This fixture provides the authentication context for requests that have
+    OAuth authentication but lack the LOLA portability scope, so they receive
+    basic ActivityPub data like unauthenticated requests.
+    
+    Args:
+        mock_request: Automatically injected mock request fixture
+        
+    Returns:
+        Dict with authentication context for OAuth-only responses
+    """
+    return {
+        'is_authenticated': True,
+        'has_portability_scope': False,
+        'request': mock_request
+    }

--- a/testbed/core/tests/test_json_ld.py
+++ b/testbed/core/tests/test_json_ld.py
@@ -17,19 +17,9 @@ from testbed.core.factories import (
 
 # Test complete flow from API to JSON-LD for Actor
 @pytest.mark.django_db
-def test_actor_json_ld_flow(actor):
-    # Create mock request to match API context
-    factory = RequestFactory()
-    mock_request = factory.get('/api/actors/')
-    mock_request.META['HTTP_HOST'] = 'testserver'
-    
+def test_actor_json_ld_flow(actor, basic_auth_context):
     # Test JSON-LD generation with proper auth_context
-    auth_context = {
-        'is_authenticated': False,
-        'has_portability_scope': False,
-        'request': mock_request
-    }
-    builder_json_ld = build_actor_json_ld(actor, auth_context)
+    builder_json_ld = build_actor_json_ld(actor, basic_auth_context)
     
     # Test API response
     client = APIClient()
@@ -43,19 +33,9 @@ def test_actor_json_ld_flow(actor):
 
 # Test complete flow from API to JSON-LD for Outbox
 @pytest.mark.django_db
-def test_complete_outbox_json_ld_flow(outbox):
-    # Create mock request to match API context
-    factory = RequestFactory()
-    mock_request = factory.get('/api/actors/')
-    mock_request.META['HTTP_HOST'] = 'testserver'
-    
+def test_complete_outbox_json_ld_flow(outbox, basic_auth_context):
     # Test JSON-LD generation for outboxes with proper auth_context
-    auth_context = {
-        'is_authenticated': False,
-        'has_portability_scope': False,
-        'request': mock_request
-    }
-    builder_json_ld = build_outbox_json_ld(outbox, auth_context)
+    builder_json_ld = build_outbox_json_ld(outbox, basic_auth_context)
     
     # Test API response
     client = APIClient()
@@ -67,19 +47,14 @@ def test_complete_outbox_json_ld_flow(outbox):
 
 # Test that all activity types appear correctly in outbox
 @pytest.mark.django_db
-def test_activity_types_in_outbox(outbox, create_activity, like_activity, follow_activity):
+def test_activity_types_in_outbox(outbox, create_activity, like_activity, follow_activity, lola_auth_context):
     # Add activities to outbox
     outbox.add_activity(create_activity)
     outbox.add_activity(like_activity)
     outbox.add_activity(follow_activity)
 
     # Use authenticated context to see all activities regardless of visibility
-    auth_context = {
-        'is_authenticated': True,
-        'has_portability_scope': True,
-        'request': None
-    }
-    json_ld = build_outbox_json_ld(outbox, auth_context)
+    json_ld = build_outbox_json_ld(outbox, lola_auth_context)
     
     # Check that we have all activity types
     activity_types = {item["type"] for item in json_ld["items"]}
@@ -98,7 +73,7 @@ def test_activity_types_in_outbox(outbox, create_activity, like_activity, follow
 
 # Test that JSON-LD structure is consistent across all builders
 @pytest.mark.django_db
-def test_json_ld_consistency(actor, note, create_activity, like_activity, follow_activity):
+def test_json_ld_consistency(actor, note, create_activity, like_activity, follow_activity, basic_auth_context):
     # Test JSON-LD structure consistency across all builders
     builders_and_objects = [
         (build_actor_json_ld, actor),
@@ -109,14 +84,14 @@ def test_json_ld_consistency(actor, note, create_activity, like_activity, follow
     ]
     
     for builder, obj in builders_and_objects:
-        json_ld = builder(obj)
+        json_ld = builder(obj, basic_auth_context)
         assert "@context" in json_ld
         assert "type" in json_ld
         assert "id" in json_ld
 
 # Test JSON-LD for remote activities
 @pytest.mark.django_db
-def test_remote_activity_json_ld(actor):
+def test_remote_activity_json_ld(actor, basic_auth_context):
     # Create activities with remote objects using factory traits
     like_activity = LikeActivityFactory(
         actor=actor,
@@ -129,8 +104,8 @@ def test_remote_activity_json_ld(actor):
     )
 
     # Test JSON-LD generation
-    like_json_ld = build_like_activity_json_ld(like_activity)
-    follow_json_ld = build_follow_activity_json_ld(follow_activity)
+    like_json_ld = build_like_activity_json_ld(like_activity, basic_auth_context)
+    follow_json_ld = build_follow_activity_json_ld(follow_activity, basic_auth_context)
 
     # Verify remote object structure
     assert like_json_ld["object"]["id"] == like_activity.object_url

--- a/testbed/core/tests/test_json_ld_builders.py
+++ b/testbed/core/tests/test_json_ld_builders.py
@@ -27,76 +27,76 @@ from testbed.core.models import Actor, CreateActivity, LikeActivity, FollowActiv
 
 # Test building JSON-LD for an actor
 @pytest.mark.django_db
-def test_build_actor_json_ld(actor):
-    json_ld = build_actor_json_ld(actor)
+def test_build_actor_json_ld(actor, basic_auth_context, mock_request):
+    json_ld = build_actor_json_ld(actor, basic_auth_context)
     
     assert json_ld["@context"] == build_actor_context()
     assert json_ld["type"] == "Person"
-    assert json_ld["id"] == build_actor_id(actor.id)
+    assert json_ld["id"] == build_actor_id(actor.id, mock_request)
     assert json_ld["preferredUsername"] == actor.username
     assert json_ld["name"] == actor.username
     assert isinstance(json_ld["previously"], list)
 
 # Test building JSON-LD for a note
 @pytest.mark.django_db
-def test_build_note_json_ld(note):
-    json_ld = build_note_json_ld(note)
+def test_build_note_json_ld(note, basic_auth_context, mock_request):
+    json_ld = build_note_json_ld(note, basic_auth_context)
     
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "Note"
-    assert json_ld["id"] == build_note_id(note.id)
-    assert json_ld["actor"] == build_actor_id(note.actor.id)
+    assert json_ld["id"] == build_note_id(note.id, mock_request)
+    assert json_ld["actor"] == build_actor_id(note.actor.id, mock_request)
     assert json_ld["content"] == note.content
     assert json_ld["visibility"] == note.visibility
 
 # Test building JSON-LD for note creation activity
 @pytest.mark.django_db
-def test_build_create_activity_json_ld_note(actor):
+def test_build_create_activity_json_ld_note(actor, basic_auth_context, mock_request):
     note = NoteFactory(actor=actor)
     activity = CreateActivityFactory(actor=actor, note=note)
-    json_ld = build_create_activity_json_ld(activity)
+    json_ld = build_create_activity_json_ld(activity, basic_auth_context)
     
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "Create"
-    assert json_ld["id"] == build_activity_id(activity.id)
-    assert json_ld["actor"] == build_actor_id(actor.id)
+    assert json_ld["id"] == build_activity_id(activity.id, mock_request)
+    assert json_ld["actor"] == build_actor_id(actor.id, mock_request)
     assert json_ld["object"]["type"] == "Note"
-    assert json_ld["object"]["id"] == build_note_id(note.id)
+    assert json_ld["object"]["id"] == build_note_id(note.id, mock_request)
 
 # Test building JSON-LD for actor creation activity
 @pytest.mark.django_db
-def test_build_create_activity_json_ld_actor_creation(actor):
+def test_build_create_activity_json_ld_actor_creation(actor, basic_auth_context, mock_request):
     activity = CreateActivityFactory(
         actor=actor,
         note=None,
         visibility="public"
     )
-    json_ld = build_create_activity_json_ld(activity)
+    json_ld = build_create_activity_json_ld(activity, basic_auth_context)
     
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "Create"
-    assert json_ld["id"] == build_activity_id(activity.id)
-    assert json_ld["actor"] == build_actor_id(actor.id)
+    assert json_ld["id"] == build_activity_id(activity.id, mock_request)
+    assert json_ld["actor"] == build_actor_id(actor.id, mock_request)
     assert json_ld["object"]["type"] == "Person"
-    assert json_ld["object"]["id"] == build_actor_id(actor.id)
+    assert json_ld["object"]["id"] == build_actor_id(actor.id, mock_request)
 
 # Test building JSON-LD for local like activity
 @pytest.mark.django_db
-def test_build_like_activity_json_ld_local(actor):
+def test_build_like_activity_json_ld_local(actor, basic_auth_context, mock_request):
     note = NoteFactory(actor=actor)
     activity = LikeActivityFactory(actor=actor, note=note)
-    json_ld = build_like_activity_json_ld(activity)
+    json_ld = build_like_activity_json_ld(activity, basic_auth_context)
     
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "Like"
-    assert json_ld["id"] == build_activity_id(activity.id)
-    assert json_ld["actor"] == build_actor_id(actor.id)
+    assert json_ld["id"] == build_activity_id(activity.id, mock_request)
+    assert json_ld["actor"] == build_actor_id(actor.id, mock_request)
     assert json_ld["object"]["type"] == "Note"
-    assert json_ld["object"]["id"] == build_note_id(note.id)
+    assert json_ld["object"]["id"] == build_note_id(note.id, mock_request)
 
 # Test building JSON-LD for remote like activity
 @pytest.mark.django_db
-def test_build_like_activity_json_ld_remote(actor):
+def test_build_like_activity_json_ld_remote(actor, basic_auth_context, mock_request):
     activity = LikeActivityFactory(
         actor=actor,
         note=None,
@@ -104,33 +104,33 @@ def test_build_like_activity_json_ld_remote(actor):
         object_data={"content": "Remote content"}
     )
     
-    json_ld = build_like_activity_json_ld(activity)
+    json_ld = build_like_activity_json_ld(activity, basic_auth_context)
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "Like"
-    assert json_ld["id"] == build_activity_id(activity.id)
-    assert json_ld["actor"] == build_actor_id(actor.id)
+    assert json_ld["id"] == build_activity_id(activity.id, mock_request)
+    assert json_ld["actor"] == build_actor_id(actor.id, mock_request)
     assert json_ld["object"]["id"] == "https://remote.example/notes/123"
     assert json_ld["object"]["content"] == "Remote content"
 
 # Test building JSON-LD for local follow activity
 @pytest.mark.django_db
-def test_build_follow_activity_json_ld_local(actor, other_actor):
+def test_build_follow_activity_json_ld_local(actor, other_actor, basic_auth_context, mock_request):
     activity = FollowActivityFactory(
         actor=actor,
         target_actor=other_actor
     )
     
-    json_ld = build_follow_activity_json_ld(activity)
+    json_ld = build_follow_activity_json_ld(activity, basic_auth_context)
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "Follow"
-    assert json_ld["id"] == build_activity_id(activity.id)
-    assert json_ld["actor"] == build_actor_id(actor.id)
+    assert json_ld["id"] == build_activity_id(activity.id, mock_request)
+    assert json_ld["actor"] == build_actor_id(actor.id, mock_request)
     assert json_ld["object"]["type"] == "Person"
-    assert json_ld["object"]["id"] == build_actor_id(other_actor.id)
+    assert json_ld["object"]["id"] == build_actor_id(other_actor.id, mock_request)
 
 # Test building JSON-LD for remote follow activity
 @pytest.mark.django_db
-def test_build_follow_activity_json_ld_remote(actor):
+def test_build_follow_activity_json_ld_remote(actor, basic_auth_context, mock_request):
     activity = FollowActivityFactory(
         actor=actor,
         target_actor=None,
@@ -138,17 +138,17 @@ def test_build_follow_activity_json_ld_remote(actor):
         target_actor_data={"preferredUsername": "remote_user"}
     )
     
-    json_ld = build_follow_activity_json_ld(activity)
+    json_ld = build_follow_activity_json_ld(activity, basic_auth_context)
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "Follow"
-    assert json_ld["id"] == build_activity_id(activity.id)
-    assert json_ld["actor"] == build_actor_id(actor.id)
+    assert json_ld["id"] == build_activity_id(activity.id, mock_request)
+    assert json_ld["actor"] == build_actor_id(actor.id, mock_request)
     assert json_ld["object"]["id"] == "https://remote.example/users/remote_user"
     assert json_ld["object"]["preferredUsername"] == "remote_user"
 
 # Test Outbox JSON-LD builder with multiple activities
 @pytest.mark.django_db
-def test_build_outbox_json_ld():
+def test_build_outbox_json_ld(lola_auth_context, mock_request):
     # Create actors with the helper function that ensures unique usernames
     actor = create_isolated_actor("json_ld_outbox_test")
     target_actor = create_isolated_actor("json_ld_target_test")
@@ -179,17 +179,12 @@ def test_build_outbox_json_ld():
     outbox.add_activity(follow_activity)
     
     # Use authenticated context to see all activities regardless of visibility
-    auth_context = {
-        'is_authenticated': True,
-        'has_portability_scope': True,
-        'request': None
-    }
-    json_ld = build_outbox_json_ld(outbox, auth_context)
+    json_ld = build_outbox_json_ld(outbox, lola_auth_context)
     
     # Check outbox structure
     assert json_ld["@context"] == build_basic_context()
     assert json_ld["type"] == "OrderedCollection"
-    assert json_ld["id"] == build_outbox_id(outbox.actor.id)
+    assert json_ld["id"] == build_outbox_id(outbox.actor.id, mock_request)
     assert isinstance(json_ld["totalItems"], int)
     assert isinstance(json_ld["items"], list)
     

--- a/testbed/core/tests/test_json_ld_utils.py
+++ b/testbed/core/tests/test_json_ld_utils.py
@@ -1,3 +1,4 @@
+import pytest
 from testbed.core.json_ld_utils import (
     JsonLDContext,
     build_basic_context,
@@ -29,22 +30,22 @@ def test_build_actor_context():
     assert JsonLDContext.LOLA in context
 
 # Test base URL builder function
-def test_build_id_url():
-    url = build_id_url("test", 123)
-    assert url == "https://example.com/test/123"
+def test_build_id_url(mock_request):
+    url = build_id_url("test", 123, mock_request)
+    assert url == "http://testserver/api/test/123"
 
-def test_build_actor_id():
-    actor_id = build_actor_id(123)
-    assert actor_id == "https://example.com/actors/123"
+def test_build_actor_id(mock_request):
+    actor_id = build_actor_id(123, mock_request)
+    assert actor_id == "http://testserver/api/actors/123"
 
-def test_build_activity_id():
-    activity_id = build_activity_id(123)
-    assert activity_id == "https://example.com/activities/123"
+def test_build_activity_id(mock_request):
+    activity_id = build_activity_id(123, mock_request)
+    assert activity_id == "http://testserver/api/activities/123"
 
-def test_build_note_id():
-    note_id = build_note_id(123)
-    assert note_id == "https://example.com/notes/123"
+def test_build_note_id(mock_request):
+    note_id = build_note_id(123, mock_request)
+    assert note_id == "http://testserver/api/notes/123"
 
-def test_build_outbox_id():
-    outbox_id = build_outbox_id(123)
-    assert outbox_id == "https://example.com/actors/123/outbox"
+def test_build_outbox_id(mock_request):
+    outbox_id = build_outbox_id(123, mock_request)
+    assert outbox_id == "http://testserver/api/actors/123/outbox"


### PR DESCRIPTION
This PR addresses feedback from PRs #187 and #185.

Close #187 

---

This method constructs an ActivityPub OrderedCollection response but the same pattern is repeated both in `following_collection` and `followers_collection`.

```python
# Build ActivityPub OrderedCollection
collection_data = {
    "@context": "<https://www.w3.org/ns/activitystreams>",
    "type": "OrderedCollection",
    "id": f"{request.scheme}://{request.get_host()}/api/actors/{pk}/following",
    "totalItems": len(items),
    "orderedItems": items
}
```

To fix it we extract the method to `json_ld_builders.py` module.

**After changes:**
```python
# In json_ld_builders.py
def build_collection_json_ld(collection_type, collection_id, items, total_items=None):
    # Build ActivityPub OrderedCollection JSON-LD
    return {
        "@context": "<https://www.w3.org/ns/activitystreams>",
        "type": "OrderedCollection",
        "id": collection_id,
        "totalItems": total_items or len(items),
        "orderedItems": items
    }
```

Then  we build  the ActivityPub OrderedCollection using the reusable template
```python
collection_id = f"{request.scheme}://{request.get_host()}/api/actors/{pk}/following" # or followers
collection_data = build_collection_json_ld(collection_id, items)

```
---

It was suggested to create a decorated called `@activitypub_content` in order to eliminate duplicated response header logic that appears across multiple ActivityPub endpoints.

```python
response = Response(collection_data)

# Set ActivityPub content-type for federation
if request.accepted_renderer.format == 'json':
    response['Content-Type'] = 'application/activity+json'
    response['Access-Control-Allow-Origin'] = '*'

return response
```

This pattern was duplicated across 4 views:

- `actor_detail`
- `portability_outbox_detail`
- `following_collection`
- `followers_collection`

We created a wrapper function that modifies the response

```python
from functools import wraps

def activitypub_content(view_func):
    # Decorator to add ActivityPub headers to JSON responses
    @wraps(view_func)
    def wrapper(request, *args, **kwargs):
        response = view_func(request, *args, **kwargs)

        # Add ActivityPub headers for JSON responses
        if hasattr(response, 'accepted_renderer') and response.accepted_renderer.format == 'json':
            response['Content-Type'] = 'application/activity+json'
            response['Access-Control-Allow-Origin'] = '*'

        return response
    return wrapper
```

Then applied the `@activitypub_content` decorator to the views and remove the duplicate header logic.

---

The iteration logic for building collection items is duplicated between `following_collection` and `followers_collection` views. 

**Following Collection:**

```python
for following in following_qs:
    if following.target_actor:
        items.append(build_actor_json_ld(following.target_actor, auth_context))
    else:
        actor_data = following.target_actor_data.copy() if following.target_actor_data else {}
        actor_data['id'] = following.target_actor_url
        items.append(actor_data)
```

**Followers Collection:**

```python
for follower in followers_qs:
    if follower.follower_actor:
        items.append(build_actor_json_ld(follower.follower_actor, auth_context))
    else:
        actor_data = follower.follower_actor_data.copy() if follower.follower_actor_data else {}
        actor_data['id'] = follower.follower_actor_url
        items.append(actor_data)
```

Both patterns handle the same logic: local actors get full JSON-LD objects, remote actors use cached data with URL injection.

To fix it we created `build_relationship_items()` method in the existing builders module.

```python
def build_relationship_items(relationships, actor_field, url_field, data_field, auth_context):
    # Build collection items from relationship querysets (Following/Followers)
    items = []
    for relationship in relationships:
        local_actor = getattr(relationship, actor_field)
        if local_actor:
            items.append(build_actor_json_ld(local_actor, auth_context))
        else:
            remote_url = getattr(relationship, url_field)
            remote_data = getattr(relationship, data_field)
            actor_data = remote_data.copy() if remote_data else {}
            actor_data['id'] = remote_url
            items.append(actor_data)
    return items
```

Then replaced the loop:

```python
items = build_relationship_items(
    relationships=following_qs,
    local_actor_field='target_actor',
    remote_url_field='target_actor_url',
    remote_data_field='target_actor_data',
    auth_context=auth_context
)
```

or with:

```python
items = build_relationship_items(
    relationships=followers_qs,
    local_actor_field='follower_actor',
    remote_url_field='follower_actor_url',
    remote_data_field='follower_actor_data',
    auth_context=auth_context
)
```

--- 

Then there was an architectural inconsistency where the JSON-LD utility functions have complex fallback logic to handle cases without a request object (for tests), but the actual tests are creating mock request objects anyway.

**Feedback:**  _You have a comment elsewhere and a bunch of special case code to use the django 'request' object to get the current server's hostname, but to fail back to having no 'request' object for tests. But here you're mocking up the 'request' object so that you do have one. Could you probably simplify one or the other? Either simplify the repetition in json_ld_utils because you always have a 'request' object, or simplify the tests because you don't need a 'request' object?_

_Or is this on the path towards one of those two outcomes..._

```python
# Create mock request to match API context
factory = RequestFactory()
mock_request = factory.get('/api/actors/')
mock_request.META['HTTP_HOST'] = 'testserver'

assert json_ld["id"] == build_actor_id(actor.id, mock_request)
```

I decided to simplified by choosing one approach consistently.

**The architectural issue:**

- **json_ld_utils functions**: Designed to work with OR without request objects (complex fallback logic)
- **Tests**: Creating mock request objects anyway (defeating the fallback purpose)

I decided to always provide request + test utility - This provides the cleanest architecture and most realistic test conditions.

But also fix the following duplicated pattern across several tests:
```python
mock_request = create_mock_request()
auth_context = {
    'is_authenticated': False,
    'has_portability_scope': False,
    'request': mock_request
}
```

A method called `mock_request` was created in `/tests/conftest.py`.

```python
@pytest.fixture
def mock_request():
    # Create a mock request for JSON-LD URL generation.
    from django.test import RequestFactory
    factory = RequestFactory()
    request = factory.get('/api/actors/')
    request.META['HTTP_HOST'] = 'testserver'
    return request
```

And then added the pytest fixtures to handle auth contexts:
```python
# In conftest.py - add these fixtures
@pytest.fixture
def basic_auth_context(mock_request):
    # Auth context for unauthenticated requests.
    return {
        'is_authenticated': False,
        'has_portability_scope': False,
        'request': mock_request
    }

@pytest.fixture
def lola_auth_context(mock_request):
    # Auth context for LOLA authenticated requests.
    return {
        'is_authenticated': True,
        'has_portability_scope': True,
        'request': mock_request
    }
    
@pytest.fixture
def oauth_auth_context(mock_request):
    # Auth context for OAuth authenticated requests without portability scope.
    return {
        'is_authenticated': True,
        'has_portability_scope': False,
        'request': mock_request
    }
```

Before (with duplicated code):
```python
mock_request = create_mock_request()
auth_context = {
    'is_authenticated': False,
    'has_portability_scope': False,
    'request': mock_request
}
json_ld = build_actor_json_ld(actor, auth_context)
```

After (clean fixture usage):
```python
def test_build_actor_json_ld(actor, basic_auth_context):
    json_ld = build_actor_json_ld(actor, basic_auth_context)
```

**Remove all fallback logic and assume request is always provided**

Before
```python
def build_outbox_id(actor_id, request=None):
    if request:
        base_url = f"{request.scheme}://{request.get_host()}"
        return f"{base_url}/api/actors/{actor_id}/outbox"
    else:
        # Fallback for cases where request is not available
        return f"https://example.com/actors/{actor_id}/outbox"
```

After

```python
def build_outbox_id(actor_id, request):
    # Build outbox URL with dynamic base URL.
    base_url = f"{request.scheme}://{request.get_host()}"
    return f"{base_url}/api/actors/{actor_id}/outbox"
```

---

There was a problem with the terminology that was updated in the `get_user_application()` method which is a transition code that ~~migrates~~ update users from the old session-based client secret storage to the new encrypted database storage

---

Lastly, there was a potential security vulnerability where clients could manipulate session-stored expiry timestamps to bypass proper token expiration, effectively allowing tokens to never expire by modifying the TOKEN_EXPIRY_SESSION_KEY value in their session.

The session token validation is explicitly designed as a demo enhancement feature, not production authentication.

### 3-Tier Authentication Architecture

The system implements a priority-based authentication hierarchy:

1. **Tier 1: Authorization Header (Production)** - "Used by external ActivityPub servers and production API clients"
2. **Tier 2: URL Parameter (Testing)** - "Development and testing convenience"
3. **Tier 3: Session Storage (Demo Enhancement)** - "Seamless demo experience"

We fixed the vulnerability by validating session tokens against the OAuth database, rather than trusting client-controllable session timestamps.

**Previous problematic code:**
```python
# Check if token has expired
expiry_timestamp = request.session.get(TOKEN_EXPIRY_SESSION_KEY)
if expiry_timestamp:
    if datetime.now().timestamp() > expiry_timestamp:
        clear_token_from_session(request)
        return None
```

**Secure replacement:**
```python
def get_token_from_session(request):
    from oauth2_provider.models import AccessToken
    
    token_string = request.session.get(ACCESS_TOKEN_SESSION_KEY)
    if not token_string:
        logger.debug("No OAuth token found in session")
        return None
        
    # Validate token against OAuth database (server-side validation)
    # This prevents clients from manipulating session expiry timestamps
    try:
        access_token = AccessToken.objects.get(token=token_string)
        if access_token.is_valid():
            logger.debug("Valid OAuth token retrieved from session")
            return token_string
        else:
            # Token is expired or invalid, clean up session
            clear_token_from_session(request)
            logger.debug("Session OAuth token expired (server-validated), cleared from session")
            return None
    except AccessToken.DoesNotExist:
        # Token doesn't exist in database, clean up session
        clear_token_from_session(request)
        logger.debug("Session OAuth token not found in database, cleared from session")
        return None
```

Now both approach (production and demo) now use the exact same `AccessToken.is_valid()` method from django-oauth-toolkit

Session authentication is now as secure as authorization header authentication - both validate server-side against the database.

- **Authorization header:** Production API clients, external ActivityPub servers
- **Session authentication:** Demo interfaces, educational tools, browser-based testing