### PR TITLE
GCP: fix sass-processor-storage-error

### DIFF
--- a/testbed/settings/production.py
+++ b/testbed/settings/production.py
@@ -34,13 +34,6 @@ STORAGES = {
             "location": "static",
         }
     },
-    "sass_processor": {
-        "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
-        "OPTIONS": {
-            "bucket_name": GS_BUCKET_NAME,
-            "location": "site-assets",
-        }
-    }
 }
 
 LOGGING = {


### PR DESCRIPTION
Removing this ensure all static files goes to static/ in GS Bucket