### PR TITLE
GCP: update staging setting to include Cloud Run default URL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,10 +22,8 @@ requests==2.32.3
 rich==14.0.0
 ruff==0.11.2
 structlog==25.2.0
-
-# Production dependencies for Cloud Run deployment
-gunicorn==23.0.0                           # Production WSGI HTTP server
-django-storages[google]==1.14.4            # Google Cloud Storage backend for Django
-google-cloud-storage==2.18.2               # Google Cloud Storage client library
-google-cloud-logging==3.11.3               # Google Cloud Logging integration
-django-google-structured-logger==2.8.10    # Structured logging formatter for GCP
+gunicorn==23.0.0
+django-storages[google]==1.14.4
+google-cloud-storage==2.18.2
+google-cloud-logging==3.11.3
+django-google-structured-logger==2.8.10

--- a/testbed/settings/production.py
+++ b/testbed/settings/production.py
@@ -38,7 +38,7 @@ STORAGES = {
         "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
         "OPTIONS": {
             "bucket_name": GS_BUCKET_NAME,
-            "location": "static",  # Same as staticfiles!
+            "location": "static",
         }
     }
 }

--- a/testbed/settings/staging.py
+++ b/testbed/settings/staging.py
@@ -2,8 +2,8 @@
 from .production import *
 
 ENVIRONMENT = "staging"
-ALLOWED_HOSTS = [".run.app"] # Temporary in order to get Cloud Run default
-SITE_URL = ""
+ALLOWED_HOSTS = ["activitypub-testbed-stg-run-737003321709.us-central1.run.app"]
+SITE_URL = "https://activitypub-testbed-stg-run-737003321709.us-central1.run.app"
 CSRF_TRUSTED_ORIGINS = ['https://' + url for url in ALLOWED_HOSTS]
 GS_BUCKET_NAME = "activitypub-testbed-stg-storage"
 


### PR DESCRIPTION
Now that we have the Cloud Run default URL we add it to ALLOWED_HOST in `staging.py`