### PR TITLE
GCP: update production setting to include Cloud Run default URL

### DIFF
--- a/testbed/settings/production.py
+++ b/testbed/settings/production.py
@@ -7,8 +7,8 @@ ENVIRONMENT = "production"
 DEBUG = False
 ALLOWED_SEED_COMMAND = False
 SECRET_KEY = env.str("DJANGO_SECRET_KEY")
-ALLOWED_HOSTS = [".run.app"] # Temporary in order to get Cloud Run default
-SITE_URL = ""
+ALLOWED_HOSTS = ["activitypub-testbed-prod-run-512458093489.us-central1.run.app"]
+SITE_URL = "https://activitypub-testbed-prod-run-512458093489.us-central1.run.app"
 
 # PostgreSQL for production
 DATABASES = {"default": env.db_url("DJ_DATABASE_CONN_STRING")}


### PR DESCRIPTION
Now that we have the Cloud Run default URL we add it to ALLOWED_HOST in `production.py`