### PR TITLE
feat: Update RFC8414 OAuth discovery endpoint for LOLA account portability Implementation

### DIFF
--- a/testbed/core/tests/test_api.py
+++ b/testbed/core/tests/test_api.py
@@ -318,67 +318,6 @@ class TestLOLAAuthenticationAPI:
         assert "accountPortabilityOauth" in data
 
 
-# LOLA Discovery Endpoint Tests
-
-"""
-Tests for .well-known/oauth-authorization-server endpoint
-RFC8414-compliant OAuth Authorization Server Metadata with LOLA extensions
-"""
-class TestLOLADiscoveryEndpoint:
-
-    @pytest.mark.django_db
-    def test_oauth_discovery_endpoint_returns_valid_metadata(self):
-        """Validate that discovery endpoint returns RFC8414-compliant OAuth metadata"""
-        client = APIClient()
-        
-        response = client.get('/.well-known/oauth-authorization-server')
-        
-        assert response.status_code == status.HTTP_200_OK
-        assert response['Content-Type'] == 'application/json'
-        assert response['Access-Control-Allow-Origin'] == '*'
-        
-        data = response.json()
-        
-        # Check required OAuth metadata fields
-        required_fields = [
-            'issuer', 'authorization_endpoint', 'token_endpoint',
-            'scopes_supported', 'response_types_supported', 'grant_types_supported'
-        ]
-        
-        for field in required_fields:
-            assert field in data, f"Missing required OAuth field: {field}"
-    
-    @pytest.mark.django_db
-    def test_discovery_includes_lola_scope_and_endpoint(self):
-        """Verify LOLA-specific parameters are included for account portability discovery"""
-        client = APIClient()
-        
-        response = client.get('/.well-known/oauth-authorization-server')
-        data = response.json()
-        
-        # LOLA scope should be supported
-        assert 'activitypub_account_portability' in data['scopes_supported']
-        
-        # LOLA endpoint parameter should be present
-        assert 'activitypub_account_portability' in data
-        assert data['activitypub_account_portability'].endswith('/oauth/authorize/')
-    
-    @pytest.mark.django_db
-    def test_discovery_endpoint_urls_are_absolute(self):
-        """Ensure all URLs in discovery response are absolute for federation compatibility"""
-        client = APIClient()
-        
-        response = client.get('/.well-known/oauth-authorization-server')
-        data = response.json()
-        
-        # All URL fields must be absolute for proper federation
-        url_fields = ['issuer', 'authorization_endpoint', 'token_endpoint', 'activitypub_account_portability']
-        
-        for field in url_fields:
-            url = data[field]
-            assert url.startswith('http'), f"{field} should be absolute URL: {url}"
-
-
 # LOLA Following Collection Tests
 
 """

--- a/testbed/core/tests/test_lola_compliance.py
+++ b/testbed/core/tests/test_lola_compliance.py
@@ -1,0 +1,126 @@
+from rest_framework.test import APIClient
+from rest_framework import status
+
+"""
+Tests for .well-known/oauth-authorization-server endpoint
+RFC8414-compliant OAuth Authorization Server Metadata with LOLA extensions
+"""
+
+# Validate that discovery endpoint returns RFC8414-compliant OAuth metadata.
+def test_rfc8414_returns_valid_metadata():
+
+    client = APIClient()
+    
+    response = client.get('/.well-known/oauth-authorization-server')
+    
+    assert response.status_code == status.HTTP_200_OK
+    assert response['Content-Type'] == 'application/json'
+    assert response['Access-Control-Allow-Origin'] == '*'
+    
+    data = response.json()
+    
+    required_fields = [
+        'issuer', 
+        'authorization_endpoint', 
+        'token_endpoint',
+        'scopes_supported', 
+        'response_types_supported', 
+        'grant_types_supported'
+    ]
+    
+    for field in required_fields:
+        assert field in data, f"Missing required OAuth field: {field}"
+
+# Verify LOLA-specific parameters are included for account portability discovery
+def test_rfc8414_includes_lola_parameters():
+    
+    client = APIClient()
+    
+    response = client.get('/.well-known/oauth-authorization-server')
+    data = response.json()
+    
+    # LOLA scope should be supported
+    assert 'activitypub_account_portability' in data['scopes_supported'], \
+        "LOLA scope 'activitypub_account_portability' must be in scopes_supported"
+    
+    # LOLA endpoint parameter should be present (LOLA extension to RFC8414)
+    assert 'activitypub_account_portability' in data, \
+        "LOLA parameter 'activitypub_account_portability' must be present"
+    assert data['activitypub_account_portability'].endswith('/oauth/authorize/'), \
+        "LOLA portability endpoint should point to OAuth authorization endpoint"
+
+
+# Ensure all URLs in discovery response are absolute for federation compatibility
+def test_rfc8414_urls_are_absolute():
+
+    client = APIClient()
+    
+    response = client.get('/.well-known/oauth-authorization-server')
+    data = response.json()
+    
+    # All URL fields must be absolute for proper federation
+    url_fields = [
+        'issuer', 
+        'authorization_endpoint', 
+        'token_endpoint', 
+        'activitypub_account_portability'
+    ]
+    
+    for field in url_fields:
+        url = data[field]
+        assert url.startswith('http'), \
+            f"{field} should be absolute URL starting with http/https: {url}"
+
+
+def test_rfc8414_authorization_code_flow_support():
+    """
+    Verify that the authorization code flow is properly advertised.
+    
+    LOLA uses OAuth 2.0 authorization code flow, so the metadata must
+    indicate support for 'code' response type and 'authorization_code' grant type.
+    """
+    client = APIClient()
+    
+    response = client.get('/.well-known/oauth-authorization-server')
+    data = response.json()
+    
+    # Authorization code flow requirements
+    assert 'code' in data['response_types_supported'], \
+        "Must support 'code' response type for authorization code flow"
+    assert 'authorization_code' in data['grant_types_supported'], \
+        "Must support 'authorization_code' grant type"
+
+
+# Verify CORS headers are present to enable cross-origin discovery
+def test_rfc8414_cors_headers_for_federation():
+    
+    client = APIClient()
+    
+    response = client.get('/.well-known/oauth-authorization-server')
+    
+    # CORS headers are essential for federation
+    assert 'Access-Control-Allow-Origin' in response, \
+        "CORS header 'Access-Control-Allow-Origin' must be present"
+    assert response['Access-Control-Allow-Origin'] == '*', \
+        "CORS should allow all origins for public discovery"
+
+
+# Verify that OAuth endpoint URLs match the actual django-oauth-toolkit routes.
+def test_rfc8414_oauth_endpoints_match():
+    
+    client = APIClient()
+    
+    response = client.get('/.well-known/oauth-authorization-server')
+    data = response.json()
+    
+    """
+    Check that OAuth endpoints use the correct paths
+    This ensures consistency between the advertised endpoints and the actual OAuth implementation.
+    """
+    assert '/oauth/authorize/' in data['authorization_endpoint'], \
+        "Authorization endpoint should use /oauth/authorize/ path"
+    assert '/oauth/token/' in data['token_endpoint'], \
+        "Token endpoint should use /oauth/token/ path"
+    
+    assert data['activitypub_account_portability'] == data['authorization_endpoint'], \
+        "LOLA portability endpoint should point to the same authorization endpoint"

--- a/testbed/core/views.py
+++ b/testbed/core/views.py
@@ -593,17 +593,17 @@ def blocked_collection(request, pk):
     return Response(collection_data)
 
 
-@api_view(['GET'])
 def oauth_authorization_server_metadata(request):
     """
     RFC8414-compliant OAuth Authorization Server Metadata endpoint for LOLA discovery.
     
     This endpoint enables automatic LOLA discovery by destination servers.
+    
     Per LOLA specification: "ActivityPub servers supporting this specification SHOULD 
     include the URL of their portability authorization endpoint in their authorization 
     server metadata document [RFC8414] using the activitypub_account_portability parameter."
     """
-    # Build the base URL dynamically from the request
+    # Build base URL from request (HTTPS handled by SECURE_PROXY_SSL_HEADER in production)
     scheme = request.scheme
     host = request.get_host()
     base_url = f"{scheme}://{host}"
@@ -612,21 +612,15 @@ def oauth_authorization_server_metadata(request):
         "issuer": base_url,
         "authorization_endpoint": f"{base_url}{reverse('oauth2_provider:authorize')}",
         "token_endpoint": f"{base_url}{reverse('oauth2_provider:token')}",
-        "scopes_supported": [
-            "activitypub_account_portability"
-        ],
-        "response_types_supported": [
-            "code"
-        ],
-        "grant_types_supported": [
-            "authorization_code"
-        ],
+        "scopes_supported": ["activitypub_account_portability"],
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code"],
         # LOLA-specific parameter for account portability endpoint discovery
         "activitypub_account_portability": f"{base_url}{reverse('oauth2_provider:authorize')}"
     }
     
     response = JsonResponse(metadata)
-    response['Access-Control-Allow-Origin'] = '*'  # Enable federation
+    response['Access-Control-Allow-Origin'] = '*'  # CORS for federation
     return response
 
 

--- a/testbed/settings/production.py
+++ b/testbed/settings/production.py
@@ -10,6 +10,9 @@ SECRET_KEY = env.str("DJANGO_SECRET_KEY")
 ALLOWED_HOSTS = ["ap-testbed.dtinit.org", "www.ap-testbed.dtinit.org", "activitypub-testbed-prod-run-512458093489.us-central1.run.app"]
 SITE_URL = "https://ap-testbed.dtinit.org/"
 
+# Cloud Run uses X-Forwarded-Proto header for HTTPS detection
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 # PostgreSQL for production
 DATABASES = {"default": env.db_url("DJ_DATABASE_CONN_STRING")}
 

--- a/testbed/settings/staging.py
+++ b/testbed/settings/staging.py
@@ -7,9 +7,6 @@ SITE_URL = "https://activitypub-testbed-stg-run-737003321709.us-central1.run.app
 CSRF_TRUSTED_ORIGINS = ['https://' + url for url in ALLOWED_HOSTS]
 GS_BUCKET_NAME = "activitypub-testbed-stg-storage"
 
-# Cloud Run uses X-Forwarded-Proto header for HTTPS detection
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-
 # Update the STORAGES configuration with the staging bucket
 for key in STORAGES:
     STORAGES[key]["OPTIONS"]["bucket_name"] = GS_BUCKET_NAME


### PR DESCRIPTION
This PR makes a complete overview and update of the _RFC8414 OAuth Authorization Server Metadata endpoint with LOLA extensions for ActivityPub account portability discovery_ Implementation.

Closes #228

* Created a new file (`testbed/core/tests/test_lola_compliance.py`) that handles the RFC8414 compliance tests
    * Delete the tests that were on `testbed/core/tests/test_api.py` for better separation of concerns
* Simplified the `oauth_authorization_server_metadata` view
* Added `SECURE_PROXY_SSL_HEADER` for HTTPS detection in Production (Staging inherits from it)

### Features that were revised/updated
1. **RFC8414-compliant metadata endpoint** at `/.well-known/oauth-authorization-server`
2. **LOLA extension** - `activitypub_account_portability` parameter for discovery
3. **HTTPS enforcement** - Proper detection behind Google Cloud Run load balancer
4. **CORS enabled** - Cross-origin federation support
5. **Comprehensive tests** - 6 RFC8414 compliance tests


## Production Deployment Notes

⚠️ __IMPORTANT:__ This PR includes the fix for HTTPS URLs in production/staging.

__Current behaviour:__ Returns `http://` URLs (incorrect)

```bash
curl -sS \
  -H "Accept: application/json" \
  https://ap-testbed.dtinit.org/.well-known/oauth-authorization-server
```

```json
{
   "issuer":"http://ap-testbed.dtinit.org",
   "authorization_endpoint":"http://ap-testbed.dtinit.org/oauth/authorize/",
   "token_endpoint":"http://ap-testbed.dtinit.org/oauth/token/",
   "scopes_supported":[
      "activitypub_account_portability"
   ],
   "response_types_supported":[
      "code"
   ],
   "grant_types_supported":[
      "authorization_code"
   ],
   "activitypub_account_portability":"http://ap-testbed.dtinit.org/oauth/authorize/"
}"%"
```

__After deployment:__ All URLs should use `https://` protocol. (correct)

The `SECURE_PROXY_SSL_HEADER` setting enables proper HTTPS detection behind Google Cloud Run's load balancer.

## Standards Compliance

- RFC8414 (OAuth Authorization Server Metadata)
- RFC8615 (Well-Known URIs)
- LOLA v0.2 (Account Portability Specification)
- OAuth 2.0 Security Best Practices

## Testing
```bash
# New LOLA compliance tests
pytest testbed/core/tests/test_lola_compliance.py -v
# Result: 6 passed 

# Existing API tests (unchanged)
pytest testbed/core/tests/test_api.py -v  
# Result: 26 passed 

Total: 32 tests passing
