### PR TITLE
GCP: add GCloud logging vars to deploy job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,6 +28,7 @@
 # - SERVICE_ACCOUNT_NAME: Email address of the service account used for Cloud Run
 # - DATABASE_NAME: PostgreSQL database name in Cloud SQL
 # - ARTIFACT_REGISTRY: Name of the container image
+# - USE_GCLOUD_LOGGING: Enable Cloud Logging
 #
 # ### GitHub Environment Secrets (per environment: Staging, Production)
 #
@@ -240,6 +241,7 @@ jobs:
           --set-env-vars DJANGO_SECRET_KEY="${{ secrets.DJANGO_SECRET_KEY }}"
           --set-env-vars DJ_DATABASE_CONN_STRING="postgres://${{ env.ENCODED_DB_CREDENTIALS }}@//cloudsql/${{ secrets.CLOUD_SQL_ICN }}/${{ vars.DATABASE_NAME }}"
           --set-env-vars EMAIL_HOST_PASSWORD="${{ secrets.EMAIL_HOST_PASSWORD }}"
+          --set-env-vars USE_GCLOUD_LOGGING="${{ vars.USE_GCLOUD_LOGGING }}"
           --allow-unauthenticated
 
 


### PR DESCRIPTION
Previous PR correctly send logs to GCloud.Just adding USE_GCLOUD_LOGGING to GitHub Repo Variables.