### PR TITLE
Update RFC8424 discovery with structured LOLA metadata

### DIFF
--- a/testbed/core/tests/test_lola_compliance.py
+++ b/testbed/core/tests/test_lola_compliance.py
@@ -46,9 +46,27 @@ def test_rfc8414_includes_lola_parameters():
     # LOLA endpoint parameter should be present (LOLA extension to RFC8414)
     assert 'activitypub_account_portability' in data, \
         "LOLA parameter 'activitypub_account_portability' must be present"
-    assert data['activitypub_account_portability'].endswith('/oauth/authorize/'), \
-        "LOLA portability endpoint should point to OAuth authorization endpoint"
-
+    
+    lola_metadata = data['activitypub_account_portability']
+    
+    assert 'supported' in lola_metadata, \
+        "LOLA metadata 'supported' flag must be present"
+        
+    assert lola_metadata['supported'] is True, \
+        "LOLA metadata 'supported' flag must be True"
+    
+    assert 'authorization_endpoint' in lola_metadata, \
+         "LOLA metadata 'authorization_endpoint' must be present"
+         
+    assert lola_metadata['authorization_endpoint'].endswith('/oauth/authorize/'), \
+        "LOLA authorization endpoint should point to OAuth authorization endpoint"
+    
+    assert 'scopes' in lola_metadata, \
+        "LOLA metadata 'scopes' must be present"
+        
+    assert 'activitypub_account_portability' in lola_metadata['scopes'], \
+        "LOLA scopes array must include 'activitypub_account_portability'"
+        
 
 # Ensure all URLs in discovery response are absolute for federation compatibility
 def test_rfc8414_urls_are_absolute():
@@ -62,14 +80,18 @@ def test_rfc8414_urls_are_absolute():
     url_fields = [
         'issuer', 
         'authorization_endpoint', 
-        'token_endpoint', 
-        'activitypub_account_portability'
+        'token_endpoint'
     ]
     
     for field in url_fields:
         url = data[field]
         assert url.startswith('http'), \
             f"{field} should be absolute URL starting with http/https: {url}"
+    
+    lola_metadata = data['activitypub_account_portability']
+    lola_auth_endpoint = lola_metadata['authorization_endpoint']
+    assert lola_auth_endpoint.startswith('http'), \
+        f"LOLA authorization_endpoint should be absolute URL: {lola_auth_endpoint}"
 
 
 def test_rfc8414_authorization_code_flow_support():
@@ -122,5 +144,6 @@ def test_rfc8414_oauth_endpoints_match():
     assert '/oauth/token/' in data['token_endpoint'], \
         "Token endpoint should use /oauth/token/ path"
     
-    assert data['activitypub_account_portability'] == data['authorization_endpoint'], \
+    lola_metadata = data['activitypub_account_portability']
+    assert lola_metadata['authorization_endpoint'] == data['authorization_endpoint'], \
         "LOLA portability endpoint should point to the same authorization endpoint"

--- a/testbed/core/views.py
+++ b/testbed/core/views.py
@@ -608,15 +608,22 @@ def oauth_authorization_server_metadata(request):
     host = request.get_host()
     base_url = f"{scheme}://{host}"
     
+    authorization_endpoint = f"{base_url}{reverse('oauth2_provider:authorize')}"
+    
     metadata = {
         "issuer": base_url,
-        "authorization_endpoint": f"{base_url}{reverse('oauth2_provider:authorize')}",
+        "authorization_endpoint": authorization_endpoint,
         "token_endpoint": f"{base_url}{reverse('oauth2_provider:token')}",
         "scopes_supported": ["activitypub_account_portability"],
         "response_types_supported": ["code"],
         "grant_types_supported": ["authorization_code"],
+        
         # LOLA-specific parameter for account portability endpoint discovery
-        "activitypub_account_portability": f"{base_url}{reverse('oauth2_provider:authorize')}"
+        "activitypub_account_portability": {
+            "supported": True,
+            "authorization_endpoint": authorization_endpoint,
+            "scopes": ["activitypub_account_portability"]
+        }
     }
     
     response = JsonResponse(metadata)

--- a/testbed/core/views.py
+++ b/testbed/core/views.py
@@ -627,6 +627,7 @@ def oauth_authorization_server_metadata(request):
     }
     
     response = JsonResponse(metadata)
+    response['Content-Type'] = 'application/json'
     response['Access-Control-Allow-Origin'] = '*'  # CORS for federation
     return response
 


### PR DESCRIPTION
This PR updates RFC8414 Discovery Endpoint with structured LOLA account portability metadata.

**Before:**
```json
"activitypub_account_portability": "<http://localhost:8000/oauth/authorize/>"
```

**After:**
```json
"activitypub_account_portability": {
  "supported": true,
  "authorization_endpoint": "<http://localhost:8000/oauth/authorize/>",
  "scopes": ["activitypub_account_portability"]
}
```

```bash
curl -s http://localhost:8000/.well-known/oauth-authorization-server | jq
```

<img width="638" height="422" alt="image" src="https://github.com/user-attachments/assets/10530c95-2f84-4eb5-ba3e-b2be0f5fce57" />

Closes #240 