### PR TITLE
fix: Use settings.BASE_URL for OAuth discovery endpoint URLs

### DIFF
--- a/testbed/core/views.py
+++ b/testbed/core/views.py
@@ -23,6 +23,7 @@ from django.urls import reverse
 import logging
 import requests
 from django.urls import reverse
+from django.conf import settings
 from functools import wraps
 
 logger = logging.getLogger(__name__)
@@ -603,10 +604,12 @@ def oauth_authorization_server_metadata(request):
     include the URL of their portability authorization endpoint in their authorization 
     server metadata document [RFC8414] using the activitypub_account_portability parameter."
     """
-    # Build base URL from request (HTTPS handled by SECURE_PROXY_SSL_HEADER in production)
-    scheme = request.scheme
-    host = request.get_host()
-    base_url = f"{scheme}://{host}"
+    if hasattr(settings, 'BASE_URL') and settings.BASE_URL:
+        base_url = settings.BASE_URL
+    else:
+        scheme = request.scheme
+        host = request.get_host()
+        base_url = f"{scheme}://{host}"
     
     authorization_endpoint = f"{base_url}{reverse('oauth2_provider:authorize')}"
     


### PR DESCRIPTION
Depends on PR #242 

The RFC8414 OAuth Authorization Server Metadata endpoint (`/.well-known/oauth-authorization-server`) was returning HTTP URLs in production instead of HTTPS, breaking LOLA account portability:

```json
{
  "issuer": "http://ap-testbed.dtinit.org",              // Should be https://
  "authorization_endpoint": "http://ap-testbed.dtinit.org/oauth/authorize/",
  "token_endpoint": "http://ap-testbed.dtinit.org/oauth/token/"
}
```

Custom domain mapping on Cloud Run creates a load balancer that terminates SSL but doesn't forward the `X-Forwarded-Proto: https` header correctly. Django's `request.scheme` returns `'http'` even though clients connect via HTTPS.

Staging works correctly (uses Cloud Run's `.run.app` domain with no load balancer), while production fails (uses custom domain `ap-testbed.dtinit.org` with load balancer).

This is a patch that unblocks the LOLA federation while I continue to investigate the infrastructure issue.

I updated `oauth_authorization_server_metadata()` on `testbed/core/views.py`
  - Import `settings` from `django.conf`
  - Check for `BASE_URL` in settings
  - Fall back to request-based detection if not available

---
- **`testbed/settings/base.py`** - `BASE_URL = "http://localhost:8000"` (development)
- **`testbed/settings/production.py`** - `BASE_URL = "https://ap-testbed.dtinit.org"` (production)
- **`testbed/settings/staging.py`** - `BASE_URL = "https://activitypub-testbed-stg-run-...` (staging)
---

**Production**
```bash
curl -s https://ap-testbed.dtinit.org/.well-known/oauth-authorization-server | jq
# Expected: "https://ap-testbed.dtinit.org"
```

- HTTPS URLs accepted by destination servers  
- LOLA account portability will be functional
- RFC8414 compliant

Closes #243 