### PR TITLE
[PR #1] LOLA: implementing authorization redirect includes activitypub_actor

### DIFF
--- a/testbed/core/json_ld_utils.py
+++ b/testbed/core/json_ld_utils.py
@@ -27,6 +27,16 @@ def build_actor_id(actor_id, request):
     base_url = f"{request.scheme}://{request.get_host()}"
     return f"{base_url}/api/actors/{actor_id}"
 
+
+# Absolute Actor URL resolved through Django's URL conf so the value matches
+# the routed `actor-detail` pattern (`actors/<int:pk>/`) exactly
+def build_absolute_actor_url(actor_id, request):
+    from django.urls import reverse
+
+    return request.build_absolute_uri(
+        reverse("actor-detail", kwargs={"pk": actor_id})
+    )
+
 def build_activity_id(activity_id, request):
     base_url = f"{request.scheme}://{request.get_host()}"
     return f"{base_url}/api/activities/{activity_id}"

--- a/testbed/core/json_ld_utils.py
+++ b/testbed/core/json_ld_utils.py
@@ -27,16 +27,6 @@ def build_actor_id(actor_id, request):
     base_url = f"{request.scheme}://{request.get_host()}"
     return f"{base_url}/api/actors/{actor_id}"
 
-
-# Absolute Actor URL resolved through Django's URL conf so the value matches
-# the routed `actor-detail` pattern (`actors/<int:pk>/`) exactly
-def build_absolute_actor_url(actor_id, request):
-    from django.urls import reverse
-
-    return request.build_absolute_uri(
-        reverse("actor-detail", kwargs={"pk": actor_id})
-    )
-
 def build_activity_id(activity_id, request):
     base_url = f"{request.scheme}://{request.get_host()}"
     return f"{base_url}/api/activities/{activity_id}"

--- a/testbed/core/oauth/__init__.py
+++ b/testbed/core/oauth/__init__.py
@@ -11,11 +11,13 @@ from .utils import (
     validate_state_from_session,
 )
 from .validators import ActivityPubOAuth2Validator
+from .views import PortabilityAuthorizationView
 
 __all__ = [
     "OptionalOAuth2Authentication",
     "OAuthApplicationForm",
     "ActivityPubOAuth2Validator",
+    "PortabilityAuthorizationView",
     "clear_token_from_session",
     "generate_secure_state",
     "get_token_from_session",

--- a/testbed/core/oauth/validators.py
+++ b/testbed/core/oauth/validators.py
@@ -132,18 +132,10 @@ class ActivityPubOAuth2Validator(OAuth2Validator):
         """
         Resolve which source Actor a newly-issued LOLA token should be bound to.
 
-        Preference order:
-          1. `request.activitypub_bound_actor_id` — the actor id the user
-             explicitly selected at the authorization step. Populated by
-             following PR's authorization view; absent today. Re-validated here
-             against (user, role=ROLE_SOURCE) so a client-supplied id cannot
-             bind to another user's actor.
-          2. Fallback: the authenticated user's unique source Actor.
-             `Actor.clean()` enforces one source actor per user, so this
-             lookup is deterministic when an actor exists.
-
-        Returns None when no valid source actor can be resolved; the caller
-        treats that as a hard failure (refuse to issue the token).
+        Returns the authenticated user's unique source Actor, or None if no
+        source actor exists (the caller treats None as a hard failure and
+        refuses to issue the token). `Actor.clean()` enforces one source actor
+        per user, so this lookup is deterministic.
         """
         # Import lazily — this module is imported by DOT at app startup before
         # the core app's models are fully available in some test configs.
@@ -153,14 +145,7 @@ class ActivityPubOAuth2Validator(OAuth2Validator):
         if user is None or not getattr(user, "is_authenticated", False):
             return None
 
-        bound_id = getattr(request, "activitypub_bound_actor_id", None)
         try:
-            if bound_id is not None:
-                return Actor.objects.get(
-                    pk=bound_id,
-                    user=user,
-                    role=Actor.ROLE_SOURCE,
-                )
             return Actor.objects.get(user=user, role=Actor.ROLE_SOURCE)
         except Actor.DoesNotExist:
             return None

--- a/testbed/core/oauth/views.py
+++ b/testbed/core/oauth/views.py
@@ -7,6 +7,8 @@ parameters:
 
     code, state, activitypub_actor
 
+https://github.com/django-oauth/django-oauth-toolkit/blob/master/oauth2_provider/views/base.py
+
 DOT already produces `code` and `state` as part of the standard OAuth 2.0
 authorization-code flow. This subclass appends `activitypub_actor` (the
 absolute URL of the source Actor that just granted portability access)

--- a/testbed/core/oauth/views.py
+++ b/testbed/core/oauth/views.py
@@ -17,7 +17,7 @@ from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunparse
 
 from oauth2_provider.views import AuthorizationView
 
-from ..json_ld_utils import build_absolute_actor_url
+from ..json_ld_utils import build_actor_id
 
 logger = logging.getLogger(__name__)
 
@@ -28,19 +28,19 @@ ACTIVITYPUB_ACTOR_PARAM = "activitypub_actor" # Query parameter name defined by 
 
 class PortabilityAuthorizationView(AuthorizationView):
     """
-    Appends `activitypub_actor` to the approval redirect for portability-scoped
-    authorizations, and binds the request to the resolved source actor so the
-    redirect actor and the token-bound actor share a single source of truth.
+    Appends `activitypub_actor` to the approval redirect for LOLA portability authorizations (LOLA §5.3).
+    The redirect value is the absolute URL of the source Actor that granted access.
     """
 
     def form_valid(self, form):
         """
         Handle the POST approval path.
 
-        Resolve the source actor and stamp `request.activitypub_bound_actor_id`
-        BEFORE delegating to DOT so the binding attribute is present when DOT
-        creates the grant/token. DOT returns an OAuth2ResponseRedirect; we then
-        append `activitypub_actor` to its Location header.
+        Resolve the source actor for the LOLA redirect, let DOT generate the approval response (DOT returns
+        an OAuth2ResponseRedirect with `code` and `state`), then append `activitypub_actor` to its Location header.
+
+        Resolution runs before super() purely so we don't append on failure paths — the redirect URL
+        itself is built from DOT's output, not from anything we attach to the request.
         """
         scopes = form.cleaned_data.get("scope") or ""
         actor = self._prepare_actor_binding(scopes)
@@ -63,8 +63,13 @@ class PortabilityAuthorizationView(AuthorizationView):
 
     def _prepare_actor_binding(self, scope_string):
         """
-        Resolve the source actor for a portability authorization and record it
-        on the request so the token validator binds to the same actor.
+        Resolve the source actor whose absolute URL will be appended to the
+        approval redirect as `activitypub_actor` (LOLA Section 5.3).
+
+        Returns the Actor for LOLA portability authorizations with a resolvable
+        source actor, otherwise None (which means: leave DOT's redirect
+        untouched). Non-LOLA authorizations always return None so regular OAuth
+        flows are unaffected.
         """
         if LOLA_PORTABILITY_SCOPE not in scope_string.split():
             return None
@@ -78,12 +83,8 @@ class PortabilityAuthorizationView(AuthorizationView):
             )
             return None
 
-        # Single source of truth: this is the same attribute
-        # ActivityPubOAuth2Validator._save_bearer_token reads when it creates
-        # the TokenActorBinding, so the redirect actor and the bound actor match.
-        self.request.activitypub_bound_actor_id = actor.pk
         logger.info(
-            "LOLA authorization: bound actor resolved actor_id=%s user_id=%s",
+            "LOLA authorization: source actor resolved for redirect actor_id=%s user_id=%s",
             actor.pk,
             getattr(getattr(self.request, "user", None), "pk", None),
         )
@@ -116,7 +117,7 @@ class PortabilityAuthorizationView(AuthorizationView):
         if "code" not in query:
             return
 
-        actor_url = build_absolute_actor_url(actor.pk, self.request)
+        actor_url = build_actor_id(actor.pk, self.request)
         response["Location"] = self._add_query_param(
             location, ACTIVITYPUB_ACTOR_PARAM, actor_url
         )

--- a/testbed/core/oauth/views.py
+++ b/testbed/core/oauth/views.py
@@ -1,0 +1,142 @@
+"""
+Custom django-oauth-toolkit (DOT) authorization view for LOLA portability.
+
+`PortabilityAuthorizationView` subclasses DOT's `AuthorizationView` to satisfy
+LOLA §5.3, which requires the source server's approval redirect to carry three
+parameters:
+
+    code, state, activitypub_actor
+
+DOT already produces `code` and `state` as part of the standard OAuth 2.0
+authorization-code flow. This subclass appends `activitypub_actor` (the
+absolute URL of the source Actor that just granted portability access)
+"""
+
+import logging
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunparse
+
+from oauth2_provider.views import AuthorizationView
+
+from ..json_ld_utils import build_absolute_actor_url
+
+logger = logging.getLogger(__name__)
+
+
+LOLA_PORTABILITY_SCOPE = "activitypub_account_portability"
+ACTIVITYPUB_ACTOR_PARAM = "activitypub_actor" # Query parameter name defined by LOLA §5.3 for the granted source Actor URL.
+
+
+class PortabilityAuthorizationView(AuthorizationView):
+    """
+    Appends `activitypub_actor` to the approval redirect for portability-scoped
+    authorizations, and binds the request to the resolved source actor so the
+    redirect actor and the token-bound actor share a single source of truth.
+    """
+
+    def form_valid(self, form):
+        """
+        Handle the POST approval path.
+
+        Resolve the source actor and stamp `request.activitypub_bound_actor_id`
+        BEFORE delegating to DOT so the binding attribute is present when DOT
+        creates the grant/token. DOT returns an OAuth2ResponseRedirect; we then
+        append `activitypub_actor` to its Location header.
+        """
+        scopes = form.cleaned_data.get("scope") or ""
+        actor = self._prepare_actor_binding(scopes)
+
+        response = super().form_valid(form)
+
+        if actor is not None:
+            self._append_actor_to_redirect(response, actor)
+        return response
+
+    def get(self, request, *args, **kwargs):
+        scopes = request.GET.get("scope", "")
+        actor = self._prepare_actor_binding(scopes)
+
+        response = super().get(request, *args, **kwargs)
+
+        if actor is not None and self._is_redirect(response):
+            self._append_actor_to_redirect(response, actor)
+        return response
+
+    def _prepare_actor_binding(self, scope_string):
+        """
+        Resolve the source actor for a portability authorization and record it
+        on the request so the token validator binds to the same actor.
+        """
+        if LOLA_PORTABILITY_SCOPE not in scope_string.split():
+            return None
+
+        actor = self._resolve_source_actor()
+        if actor is None:
+            logger.warning(
+                "LOLA authorization: no resolvable source actor for user_id=%s; "
+                "activitypub_actor will be omitted from redirect",
+                getattr(getattr(self.request, "user", None), "pk", None),
+            )
+            return None
+
+        # Single source of truth: this is the same attribute
+        # ActivityPubOAuth2Validator._save_bearer_token reads when it creates
+        # the TokenActorBinding, so the redirect actor and the bound actor match.
+        self.request.activitypub_bound_actor_id = actor.pk
+        logger.info(
+            "LOLA authorization: bound actor resolved actor_id=%s user_id=%s",
+            actor.pk,
+            getattr(getattr(self.request, "user", None), "pk", None),
+        )
+        return actor
+
+    def _resolve_source_actor(self):
+        # Resolve the approving user's source Actor.
+        from ..models import Actor
+
+        user = getattr(self.request, "user", None)
+        if user is None or not getattr(user, "is_authenticated", False):
+            return None
+
+        try:
+            return Actor.objects.get(user=user, role=Actor.ROLE_SOURCE)
+        except Actor.DoesNotExist:
+            return None
+
+    def _append_actor_to_redirect(self, response, actor):
+        """
+        Append `activitypub_actor=<absolute Actor URL>` to a successful
+        approval redirect's Location header, preserving everything DOT already
+        put there.
+        """
+        location = response.get("Location")
+        if not location:
+            return
+
+        query = parse_qs(urlparse(location).query)
+        if "code" not in query:
+            return
+
+        actor_url = build_absolute_actor_url(actor.pk, self.request)
+        response["Location"] = self._add_query_param(
+            location, ACTIVITYPUB_ACTOR_PARAM, actor_url
+        )
+        logger.info(
+            "LOLA authorization: appended %s to redirect actor_id=%s",
+            ACTIVITYPUB_ACTOR_PARAM,
+            actor.pk,
+        )
+
+    @staticmethod
+    def _add_query_param(url, key, value):
+        parsed = urlparse(url)
+        query = parse_qsl(parsed.query, keep_blank_values=True)
+        query.append((key, value))
+        new_query = urlencode(query)
+        return urlunparse(parsed._replace(query=new_query))
+
+    @staticmethod
+    def _is_redirect(response):
+        # True when the response is an HTTP redirect carrying a Location header
+        return 300 <= getattr(response, "status_code", 0) < 400 and response.has_header(
+            "Location"
+        )

--- a/testbed/core/tests/test_authorization_view.py
+++ b/testbed/core/tests/test_authorization_view.py
@@ -256,8 +256,13 @@ def test_redirect_actor_matches_token_bound_actor():
     access_token = get_access_token_model().objects.get(token=access_token_str)
     binding = TokenActorBinding.objects.get(token=access_token)
 
-    # Binding actor and redirect actor are the same source actor. Compare the
-    # full canonical URL so this also locks the redirect-vs-JSON-LD `id`
-    # byte-identity that LOLA Section 5.3 destinations rely on.
+    # Binding actor and redirect actor are the same source actor. They agree
+    # because `PortabilityAuthorizationView._resolve_source_actor()` and
+    # `ActivityPubOAuth2Validator._resolve_bound_actor()` independently run
+    # the same `Actor.objects.get(user, role=ROLE_SOURCE)` lookup, unique by
+    # `Actor.clean()`.
+    
+    # Comparing the full canonical URL also locks the redirect-vs-
+    # JSON-LD `id` byte-identity that LOLA Section 5.3 destinations rely on.
     assert binding.actor_id == source_actor.pk
     assert redirect_actor_url == _expected_actor_url(source_actor)

--- a/testbed/core/tests/test_authorization_view.py
+++ b/testbed/core/tests/test_authorization_view.py
@@ -1,0 +1,254 @@
+import base64
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from oauth2_provider.models import Application, get_access_token_model
+
+from testbed.core.factories import AccessTokenFactory, UserWithActorsFactory
+from testbed.core.models import Actor, TokenActorBinding
+from testbed.core.oauth.views import ACTIVITYPUB_ACTOR_PARAM
+
+LOLA_SCOPE = "activitypub_account_portability"
+REDIRECT_URI = "https://destination.example/callback"
+
+
+def _make_application(owner, *, skip_authorization=False, client_secret="test-secret"):
+    # Create a confidential authorization-code application registered for the LOLA redirect URI.
+    return Application.objects.create(
+        name="Destination Service",
+        user=owner,
+        client_type=Application.CLIENT_CONFIDENTIAL,
+        authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        redirect_uris=REDIRECT_URI,
+        skip_authorization=skip_authorization,
+        client_secret=client_secret,
+    )
+
+
+def _authorize_params(application, *, scope=LOLA_SCOPE, state="state-xyz", **extra):
+    # Standard query/form params for an authorization request
+    params = {
+        "client_id": application.client_id,
+        "response_type": "code",
+        "scope": scope,
+        "redirect_uri": REDIRECT_URI,
+        "state": state,
+    }
+    params.update(extra)
+    return params
+
+
+def _redirect_query(response):
+    # Parse the query dict out of a redirect response's Location header
+    location = response["Location"]
+    return parse_qs(urlparse(location).query)
+
+
+# 1. form_valid (POST approval) path
+
+
+@pytest.mark.django_db
+def test_form_valid_redirect_includes_activitypub_actor():
+    # POST approval redirect carries code, state, and activitypub_actor
+    user = UserWithActorsFactory()
+    source_actor = user.actors.get(role=Actor.ROLE_SOURCE)
+    application = _make_application(user)
+
+    client = Client()
+    client.force_login(user)
+
+    form_data = _authorize_params(application)
+    form_data["allow"] = "True"
+    response = client.post(reverse("oauth2_provider:authorize"), data=form_data)
+
+    assert response.status_code == 302
+    query = _redirect_query(response)
+
+    assert "code" in query
+    assert query["state"] == ["state-xyz"]
+
+    assert ACTIVITYPUB_ACTOR_PARAM in query
+    actor_url = query[ACTIVITYPUB_ACTOR_PARAM][0]
+    assert actor_url.startswith("http")
+    assert actor_url.endswith(f"/api/actors/{source_actor.pk}/")
+
+
+@pytest.mark.django_db
+def test_form_valid_denied_authorization_has_no_actor():
+    # A denied authorization is an error redirect, no actor URL
+    user = UserWithActorsFactory()
+    application = _make_application(user)
+
+    client = Client()
+    client.force_login(user)
+
+    form_data = _authorize_params(application)
+    response = client.post(reverse("oauth2_provider:authorize"), data=form_data)
+
+    assert response.status_code == 302
+    query = _redirect_query(response)
+    assert "error" in query
+    assert ACTIVITYPUB_ACTOR_PARAM not in query
+
+
+# 2. skip_authorization branch (GET)
+
+
+@pytest.mark.django_db
+def test_skip_authorization_redirect_includes_activitypub_actor():
+    # GET with skip_authorization app redirects with activitypub_actor
+    user = UserWithActorsFactory()
+    source_actor = user.actors.get(role=Actor.ROLE_SOURCE)
+    application = _make_application(user, skip_authorization=True)
+
+    client = Client()
+    client.force_login(user)
+
+    response = client.get(
+        reverse("oauth2_provider:authorize"), data=_authorize_params(application)
+    )
+
+    assert response.status_code == 302
+    query = _redirect_query(response)
+    assert "code" in query
+    assert query["state"] == ["state-xyz"]
+    assert query[ACTIVITYPUB_ACTOR_PARAM][0].endswith(
+        f"/api/actors/{source_actor.pk}/"
+    )
+
+
+# 3. approval_prompt
+
+
+@pytest.mark.django_db
+def test_auto_approval_redirect_includes_activitypub_actor():
+    # GET with approval_prompt=auto reuses a prior matching access token and redirects without a form, still carrying activitypub_actor
+    
+    user = UserWithActorsFactory()
+    source_actor = user.actors.get(role=Actor.ROLE_SOURCE)
+    application = _make_application(user)
+
+    client = Client()
+    client.force_login(user)
+
+    AccessTokenFactory(user=user, application=application, lola_scope=True)
+
+    response = client.get(
+        reverse("oauth2_provider:authorize"),
+        data=_authorize_params(application, approval_prompt="auto"),
+    )
+
+    assert response.status_code == 302
+    query = _redirect_query(response)
+    assert "code" in query
+    assert query[ACTIVITYPUB_ACTOR_PARAM][0].endswith(
+        f"/api/actors/{source_actor.pk}/"
+    )
+
+
+# Non-LOLA scope: regular OAuth untouched
+
+
+@pytest.mark.django_db
+def test_non_portability_scope_redirect_has_no_actor(settings):
+    # An authorization without the portability scope must not get activitypub_actor, so regular OAuth flows are unaffected.
+    settings.OAUTH2_PROVIDER = {
+        **settings.OAUTH2_PROVIDER,
+        "SCOPES": {**settings.OAUTH2_PROVIDER["SCOPES"], "read": "Read access"},
+    }
+
+    user = UserWithActorsFactory()
+    application = _make_application(user)
+
+    client = Client()
+    client.force_login(user)
+
+    form_data = _authorize_params(application, scope="read")
+    form_data["allow"] = "True"
+    response = client.post(reverse("oauth2_provider:authorize"), data=form_data)
+
+    assert response.status_code == 302
+    query = _redirect_query(response)
+    assert ACTIVITYPUB_ACTOR_PARAM not in query
+
+
+# Security: actor comes from the approving user, never the client/app owner
+
+
+@pytest.mark.django_db
+def test_actor_is_resolved_from_approving_user_not_app_owner():
+    """
+    The redirect actor must be the approving (logged-in) user's source actor,
+    not the source actor of whoever registered the destination application.
+    """
+    app_owner = UserWithActorsFactory()
+    approving_user = UserWithActorsFactory()
+    approving_source = approving_user.actors.get(role=Actor.ROLE_SOURCE)
+    app_owner_source = app_owner.actors.get(role=Actor.ROLE_SOURCE)
+
+    application = _make_application(app_owner)
+
+    client = Client()
+    client.force_login(approving_user)
+
+    form_data = _authorize_params(application)
+    form_data["allow"] = "True"
+    response = client.post(reverse("oauth2_provider:authorize"), data=form_data)
+
+    query = _redirect_query(response)
+    actor_url = query[ACTIVITYPUB_ACTOR_PARAM][0]
+    assert actor_url.endswith(f"/api/actors/{approving_source.pk}/")
+    assert not actor_url.endswith(f"/api/actors/{app_owner_source.pk}/")
+
+
+# Alignment: redirect actor == token-bound actor (end-to-end)
+
+
+@pytest.mark.django_db
+def test_redirect_actor_matches_token_bound_actor():
+    """
+    End-to-end: the activitypub_actor in the approval redirect identifies the
+    same Actor the issued token is bound to via TokenActorBinding (LOLA §5).
+    """
+    user = UserWithActorsFactory()
+    source_actor = user.actors.get(role=Actor.ROLE_SOURCE)
+    client_secret = "exchange-secret"
+    application = _make_application(user, client_secret=client_secret)
+
+    client = Client()
+    client.force_login(user)
+
+    # Approve and capture both code and the redirect actor URL.
+    form_data = _authorize_params(application)
+    form_data["allow"] = "True"
+    approve = client.post(reverse("oauth2_provider:authorize"), data=form_data)
+    query = _redirect_query(approve)
+    code = query["code"][0]
+    redirect_actor_url = query[ACTIVITYPUB_ACTOR_PARAM][0]
+
+    # Exchange the code for a token (confidential client -> HTTP Basic auth).
+    basic = base64.b64encode(
+        f"{application.client_id}:{client_secret}".encode()
+    ).decode()
+    token_response = client.post(
+        reverse("oauth2_provider:token"),
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": REDIRECT_URI,
+        },
+        HTTP_AUTHORIZATION=f"Basic {basic}",
+    )
+
+    assert token_response.status_code == 200
+    access_token_str = token_response.json()["access_token"]
+
+    access_token = get_access_token_model().objects.get(token=access_token_str)
+    binding = TokenActorBinding.objects.get(token=access_token)
+
+    # Binding actor and redirect actor are the same source actor.
+    assert binding.actor_id == source_actor.pk
+    assert redirect_actor_url.endswith(f"/api/actors/{binding.actor_id}/")

--- a/testbed/core/tests/test_authorization_view.py
+++ b/testbed/core/tests/test_authorization_view.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from oauth2_provider.models import Application, get_access_token_model
 
 from testbed.core.factories import AccessTokenFactory, UserWithActorsFactory
+from testbed.core.json_ld_utils import build_actor_id
 from testbed.core.models import Actor, TokenActorBinding
 from testbed.core.oauth.views import ACTIVITYPUB_ACTOR_PARAM
 
@@ -47,6 +48,13 @@ def _redirect_query(response):
     return parse_qs(urlparse(location).query)
 
 
+def _expected_actor_url(actor):
+    from django.test import RequestFactory
+
+    request = RequestFactory().get("/oauth/authorize/")
+    return build_actor_id(actor.pk, request)
+
+
 # 1. form_valid (POST approval) path
 
 
@@ -72,8 +80,9 @@ def test_form_valid_redirect_includes_activitypub_actor():
 
     assert ACTIVITYPUB_ACTOR_PARAM in query
     actor_url = query[ACTIVITYPUB_ACTOR_PARAM][0]
-    assert actor_url.startswith("http")
-    assert actor_url.endswith(f"/api/actors/{source_actor.pk}/")
+    # Full-URL equality: identical to the canonical Actor `id` a destination
+    # will see when it later dereferences the URL and parses the JSON-LD.
+    assert actor_url == _expected_actor_url(source_actor)
 
 
 @pytest.mark.django_db
@@ -115,9 +124,7 @@ def test_skip_authorization_redirect_includes_activitypub_actor():
     query = _redirect_query(response)
     assert "code" in query
     assert query["state"] == ["state-xyz"]
-    assert query[ACTIVITYPUB_ACTOR_PARAM][0].endswith(
-        f"/api/actors/{source_actor.pk}/"
-    )
+    assert query[ACTIVITYPUB_ACTOR_PARAM][0] == _expected_actor_url(source_actor)
 
 
 # 3. approval_prompt
@@ -144,9 +151,7 @@ def test_auto_approval_redirect_includes_activitypub_actor():
     assert response.status_code == 302
     query = _redirect_query(response)
     assert "code" in query
-    assert query[ACTIVITYPUB_ACTOR_PARAM][0].endswith(
-        f"/api/actors/{source_actor.pk}/"
-    )
+    assert query[ACTIVITYPUB_ACTOR_PARAM][0] == _expected_actor_url(source_actor)
 
 
 # Non-LOLA scope: regular OAuth untouched
@@ -200,8 +205,10 @@ def test_actor_is_resolved_from_approving_user_not_app_owner():
 
     query = _redirect_query(response)
     actor_url = query[ACTIVITYPUB_ACTOR_PARAM][0]
-    assert actor_url.endswith(f"/api/actors/{approving_source.pk}/")
-    assert not actor_url.endswith(f"/api/actors/{app_owner_source.pk}/")
+    # Compare full URLs to avoid substring matches (e.g. `/api/actors/1` vs
+    # `/api/actors/11`) and verify the redirect references the exact approving actor.
+    assert actor_url == _expected_actor_url(approving_source)
+    assert actor_url != _expected_actor_url(app_owner_source)
 
 
 # Alignment: redirect actor == token-bound actor (end-to-end)
@@ -249,6 +256,8 @@ def test_redirect_actor_matches_token_bound_actor():
     access_token = get_access_token_model().objects.get(token=access_token_str)
     binding = TokenActorBinding.objects.get(token=access_token)
 
-    # Binding actor and redirect actor are the same source actor.
+    # Binding actor and redirect actor are the same source actor. Compare the
+    # full canonical URL so this also locks the redirect-vs-JSON-LD `id`
+    # byte-identity that LOLA Section 5.3 destinations rely on.
     assert binding.actor_id == source_actor.pk
-    assert redirect_actor_url.endswith(f"/api/actors/{binding.actor_id}/")
+    assert redirect_actor_url == _expected_actor_url(source_actor)

--- a/testbed/core/tests/test_token_actor_binding.py
+++ b/testbed/core/tests/test_token_actor_binding.py
@@ -43,17 +43,14 @@ def test_one_token_one_binding_enforced():
 def test_validator_creates_binding_for_portability_token():
     """_save_bearer_token creates a TokenActorBinding for portability-scoped tokens."""
     user = UserOnlyFactory()
-    # Use the source Actor the post_save signal auto-created for this user.
-    # _resolve_bound_actor's fallback path does Actor.objects.get(user=...,
-    # role=ROLE_SOURCE) and requires exactly one source actor per user.
+    # _resolve_bound_actor runs Actor.objects.get(user=..., role=ROLE_SOURCE),
+    # which requires exactly one source actor per user. Reuse the source actor
+    # the post_save signal auto-created.
     actor = user.actors.get(role=Actor.ROLE_SOURCE)
     access_token = AccessTokenFactory(user=user, lola_scope=True)
 
     mock_request = MagicMock()
     mock_request.user = user
-    # MagicMock auto-creates attributes, which would push _resolve_bound_actor
-    # into the preferred-id branch. Force the fallback path explicitly.
-    mock_request.activitypub_bound_actor_id = None
 
     token_dict = {"access_token": access_token.token, "scope": access_token.scope}
 
@@ -76,7 +73,6 @@ def test_validator_skips_binding_for_non_portability_token():
 
     mock_request = MagicMock()
     mock_request.user = user
-    mock_request.activitypub_bound_actor_id = None
 
     token_dict = {"access_token": access_token.token, "scope": "read write"}
 

--- a/testbed/urls.py
+++ b/testbed/urls.py
@@ -18,6 +18,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from testbed.core.views import oauth_authorization_server_metadata
+from testbed.core.oauth import PortabilityAuthorizationView
 
 urlpatterns = [
     # Admin Panel
@@ -32,7 +33,13 @@ urlpatterns = [
     path("api/", include("testbed.core.urls.api_urls")),
     # allauth
     path("account/", include("allauth.urls")),
-    # OAuth2 provider endpoints
+    # LOLA authorization override
+    path(
+        "oauth/authorize/",
+        PortabilityAuthorizationView.as_view(),
+        name="authorize",
+    ),
+    # OAuth2 provider endpoints (token, revoke, introspect, etc.)
     path("oauth/", include("oauth2_provider.urls", namespace="oauth2_provider")),
     # Regular views (no prefix)
     path("", include("testbed.core.urls.views_urls")),


### PR DESCRIPTION
Closes #253

This PR implements [LOLA §5.3](https://swicg.github.io/activitypub-data-portability/lola#source-server-response):

```markdown
### 5.3 Source server response
If authorization is approved, the source server redirects the user back to the destination server with an authorization code with parameters:

code - the authorization code
state - the same random string passed by destination server
activitypub_actor - the ActivityPub Actor ID associated with the one account that access is granted to.

It is possible for the user to provide one Actor ID to the destination server, and then for the destination server to receive a different Actor ID in this response. The destination server MAY confirm this with the user but MUST use the Actor ID provided with the authorization code rather than the original one the user communicated.
```

Before this PR the source emitted only `code` and `state`. Now it will become `code` + `state` + `activitypub_actor`.

LOLA §5.3 indicates that the source server's authorization-approval redirect carry the three previously mentioned query parameters. `code` and `state` are produced by `django-oauth-toolkit` (**DOT**) as part of its standard OAuth 2.0 authorization-code.

The implementation already has the important backend security property, it does actor-bound tokens but it does not yet surface that actor identity back in the authorization redirect. This feature does not "invent" an actor identity, it just exposing, earlier, the same actor we use later when issuing the token.

**A few things worth to mention:**

* The emitted `activitypub_actor` is an absolute actor URL, consistent with the project's actor URLs.
* This feature also allow consistency between two moments in the process:
    * callback time: the destination needs to know which actor just granted access
    * token time: the source server bind the eventual access token to a specific actor
    * Currently, the token-binding side is already implemented in `validators.py`. What was missing was the earlier authorization redirect exposing the same actor identity to the destination
* It fails closed. if the user has no source Actor, this implementation don't append a malformed/empty `activitypub_actor`. It just simple logs it and return DOT's redirect unchanged so the flow doesn't silently emit a half-shaped LOLA redirect. In practice, every user has a source Actor via the post-save signal, this just guards the edge case.
* I only append for portability-scoped authorizations. If the requested scopes don't include `activitypub_account_portability`, I leave the redirect alone. Non-LOLA OAuth flows are unaffected.
* An explicit `path("oauth/authorize/", PortabilityAuthorizationView.as_view(), name="authorize")` is registered before the `path("oauth/", include("oauth2_provider.urls", namespace="oauth2_provider"))`. Django dispatch is first-match-wins, so `/oauth/authorize/` resolves to the subclass while every other DOT endpoint (`/oauth/token/`, `/oauth/revoke_token/`, etc.) keeps resolving.
* The subclass overrides `form_valid` (POST approval) and `get()` (which covers DOT's `skip_authorization` and `approval_prompt=auto` branches). These are the places where DOT 3.0.1 calls `create_authorization_response()` to build a success redirect, and they all are in the same class, so one helper covers all three with a single test per branch.
* Two guards in `_append_actor_to_redirect` keep the parameter out of the wrong places: it only appends when the redirect's query carries code (so denial / error redirects like `error=access_denied` are left alone), and on the GET path it only appends when the response is an actual 3xx; the 200 consent-form render passes through untouched.
* `_add_query_param` and `_is_redirect` are `@staticmethod` since I just wanted to pack these methods under one class for organization.
* I did some updates related to a planning `activitypub_bound_actor_id` feature. I had the idea of having a "shared attribute" mechanism which will allow stamping`request.activitypub_bound_actor_id = actor.pk` in the view and reading it back in `ActivityPubOAuth2Validator._save_bearer_token`.
    * What actually kept the redirect actor and the token-bound actor in agreement was that both `PortabilityAuthorizationView._resolve_source_actor()` and `ActivityPubOAuth2Validator._resolve_bound_actor()` independently execute the same `Actor.objects.get(user=user, role=ROLE_SOURCE)` query, returning the same row because `Actor.clean()` enforces one source Actor per user.
    * I already know how to implement this feature but I thought it's out of scope for this task.
    * I would persist the chosen actor onto the Grant during `save_authorization_code` and reusing it during token issuance. Today's one-source-actor-per-user invariant makes the deterministic-lookup mechanism sufficient.
* Corresponding tests included.

---
<details>

<summary>A bug that I need to take care of later on but worth mention now</summary>

First I decided to create a function `build_absolute_actor_url` and not use the existing `build_actor_id`.

```python
def build_actor_id(actor_id, request):
    base_url = f"{request.scheme}://{request.get_host()}"
    return f"{base_url}/api/actors/{actor_id}"
```

```python
def build_absolute_actor_url(actor_id, request):
    return request.build_absolute_uri(
        reverse("actor-detail", kwargs={"pk": actor_id})
    )
```

```python
urlpatterns = [
    # Actor Endpoint: Retrieve actor details
    path("actors/<int:pk>/", actor_detail, name="actor-detail"),
```

The problem was that `build_absolute_actor_url` returns the `reverse()` form, which includes the trailing slash, while the JSON-LD `id` field everywhere else in the codebase emits the no-slash `build-actor-id` form.

Since LOLA §5.3 requires the destination to compare/use activitypub_actor as the Actor ID, if the two strings aren't identical, a strict comparison on the destination side fails even though the same Actor is involved.

So I chose the no-slash form which is the canonical for this project so far. It's already what every Actor publishes as `id`. Migrating everything to the `reverse()` slash form is a real refactor that touches JSON-LD output, existing tests, etc and is out of scope for this task.

So we have two scenarios over here:

| Step | Scenario A: `activitypub_actor` = no-slash (delegate to `build_actor_id`) | Scenario B: `activitypub_actor` = with-slash (`reverse()` form) |
|:-:|:-:|:-:|
| 1\. Destination GETs activitypub_actor URL | hits /api/actors/1 → 301 → /api/actors/1/ → 200 | hits /api/actors/1/ → 200 |
| 2\. JSON-LD response | {"id": "<http://host/api/actors/1>"} (no slash — build_actor_id emits this) | {"id": "<http://host/api/actors/1>"} (same — build_actor_id is unchanged) |
| 3\. Compare activitypub_actor against the document's id | http://host/api/actors/1 == <http://host/api/actors/1> → **match** | http://host/api/actors/1/ != <http://host/api/actors/1> → **mismatch** |

**Scenario A — send** `/api/actors/1` **(no slash):**
1. Django's URL resolver looks for an exact match against `/api/actors/1`. No registered pattern matches because the only pattern is `/api/actors/1/`.
2. Django's **CommonMiddleware** then uses `APPEND_SLASH=True` , which is the default. It tries appending a slash → `/api/actors/1/`. That matches a route, so the middleware returns an HTTP 301 redirect pointing the client at `/api/actors/1/`.
3. The destination's HTTP client follows the 301 (default behavior of requests, curl, browsers, etc.) and re-sends a GET to `/api/actors/1/`.
4. That request now matches the route, dispatches to the view, returns 200 with the JSON-LD.

The `APPEND_SLASH` only redirects for GET requests. For POST, etc, and unmatched no-slash URL would just return 404.

</details>
 