### PR TITLE
[PR #4] Updating Discovery / Authorization and Callback Handling Documentation

### DIFF
--- a/docs/lola-authentication.md
+++ b/docs/lola-authentication.md
@@ -410,10 +410,14 @@ The binding is persisted inside the same `transaction.atomic()` block DOT
 1. `super()._save_bearer_token(...)` lets DOT write the `AccessToken` row.
 2. If the issued scope does not include `activitypub_account_portability`,
    the validator early-returns (non-portability tokens are not actor-keyed).
-3. The validator resolves the source Actor to bind via `_resolve_bound_actor`:
-   - Preferred: `request.activitypub_bound_actor_id` (set by the authorization
-     view; re-validated against `user` and `role=ROLE_SOURCE`).
-   - Fallback: `Actor.objects.get(user=request.user, role=ROLE_SOURCE)`.
+3. The validator resolves the source Actor to bind via `_resolve_bound_actor`,
+   which performs a single deterministic lookup:
+   `Actor.objects.get(user=request.user, role=ROLE_SOURCE)`. `Actor.clean()`
+   enforces one source Actor per user, so this lookup is unambiguous. The
+   authorization view (`PortabilityAuthorizationView`) resolves the redirect's
+   `activitypub_actor` with the *same* lookup independently — that shared
+   invariant, not any cross-request attribute passing, is what keeps the
+   redirect Actor and the token-bound Actor aligned.
 4. If no valid source Actor is resolvable, the validator raises
    `InvalidRequestFatalError`, which rolls back the transaction and prevents
    an unbound portability token from being issued (fail closed).
@@ -470,6 +474,16 @@ A mismatched/missing binding produces a standardized 403 response
 }
 ```
 
+### Relationship to the `activitypub_actor` Callback
+
+The actor a token is bound to is the *same* actor the source server names in the authorization callback. On an approved portability authorization,
+the source redirect carries `code`, `state`, and `activitypub_actor` (LOLA §5.3), where `activitypub_actor` is the absolute URL of the granted source Actor.
+
+`PortabilityAuthorizationView` (which appends `activitypub_actor`) and `ActivityPubOAuth2Validator._save_bearer_token` (which writes the binding) each
+resolve that Actor independently with the same deterministic lookup (`Actor.objects.get(user=user, role=ROLE_SOURCE)`).
+Because `Actor.clean()` enforces one source Actor per user, both resolve the same row, so the Actor advertised in the callback always matches the Actor the issued token can access.
+See [Phase 3: Authorization Code & Callback Handling](oauth/phase-3-authorization-code-and-callback-handling.md#source-server-response-appending-activitypub_actor-lola-53).
+
 ## Enhanced API Endpoints
 
 Two core ActivityPub endpoints have been enhanced with LOLA authentication support:
@@ -499,14 +513,28 @@ Two core ActivityPub endpoints have been enhanced with LOLA authentication suppo
   "id": "https://example.com/actors/1",
   
   // Standard ActivityPub fields...
-  
-  // LOLA-specific fields (only with portability scope)
-  "accountPortabilityOauth": "https://example.com/oauth/authorize/",
+
+  // endpoints is ALWAYS present, even unauthenticated (public OAuth discovery surface, LOLA §4.2)
+  "endpoints": {
+    "oauthAuthorizationEndpoint": "https://example.com/oauth/authorize/",
+    "oauthMigrationEndpoint": "https://example.com/oauth/authorize/"
+  },
+
+  // The fields below are added ONLY with a valid portability-scoped token.
+  // Regular Actor collections (liked/followers are NOT migration collections):
+  "outbox": "https://example.com/actors/1/outbox",
   "following": "https://example.com/actors/1/following",
   "followers": "https://example.com/actors/1/followers",
-  "content": "https://example.com/actors/1/content",
-  "blocked": "https://example.com/actors/1/blocked", 
-  "migration": "https://example.com/actors/1/outbox"
+  "liked": "https://example.com/actors/1/liked",
+  "blocked": "https://example.com/actors/1/blocked",
+
+  // Migration feature discovery -> dedicated migration/... routes (LOLA §4.4)
+  "migration": {
+    "outbox": "https://example.com/actors/1/migration/outbox",
+    "content": "https://example.com/actors/1/migration/content",
+    "following": "https://example.com/actors/1/migration/following",
+    "blocked": "https://example.com/actors/1/migration/blocked"
+  }
 }
 ```
 
@@ -914,8 +942,10 @@ class TestLOLAAuthenticationAPI:
         assert data["preferredUsername"] == actor.username
         
     def assert_has_lola_fields(self, data, actor):
-        assert "accountPortabilityOauth" in data
-        assert data["accountPortabilityOauth"].endswith("/oauth/authorize/")
+        # endpoints.oauthMigrationEndpoint is the always-public discovery surface
+        assert data["endpoints"]["oauthMigrationEndpoint"].endswith("/oauth/authorize/")
+        # migration.* are the dedicated migration-collection routes (scope-gated)
+        assert data["migration"]["content"].endswith(f"/actors/{actor.id}/migration/content")
         # ... additional LOLA field validations
     
     def get_authenticated_client(self, token):
@@ -936,14 +966,13 @@ def test_actor_detail_with_lola_scope_returns_enhanced_data(self, lola_token):
     assert data["preferredUsername"] == actor.username
     
     # Validate LOLA-specific fields are present
-    assert "accountPortabilityOauth" in data
-    assert "content" in data
+    assert "endpoints" in data
     assert "blocked" in data
-    assert "migration" in data
-    
+    assert set(data["migration"]) == {"outbox", "content", "following", "blocked"}
+
     # Validate URL formats
-    assert data["accountPortabilityOauth"].endswith("/oauth/authorize/")
-    assert data["content"].endswith(f"/actors/{actor.id}/content")
+    assert data["endpoints"]["oauthMigrationEndpoint"].endswith("/oauth/authorize/")
+    assert data["migration"]["content"].endswith(f"/actors/{actor.id}/migration/content")
 ```
 
 #### Content Filtering Validation
@@ -994,11 +1023,13 @@ headers = {'Authorization': f'Bearer {token}'}
 response = requests.get('https://server.example/api/actors/1/', headers=headers)
 actor_data = response.json()
 
-# LOLA-specific fields now available
-print(actor_data['accountPortabilityOauth'])  # OAuth endpoint for discovery
-print(actor_data['content'])                  # Content collection endpoint
-print(actor_data['blocked'])                  # Blocked actors endpoint
-print(actor_data['migration'])                # Migration outbox endpoint
+# Public discovery surface (present even without a token)
+print(actor_data['endpoints']['oauthMigrationEndpoint'])  # OAuth endpoint for portability discovery
+
+# Migration feature discovery (only with portability scope)
+print(actor_data['migration']['content'])     # Content collection endpoint
+print(actor_data['migration']['outbox'])      # Migration outbox endpoint
+print(actor_data['blocked'])                  # Blocked actors collection
 
 # Access complete outbox (including private activities)
 outbox_response = requests.get(
@@ -1120,15 +1151,15 @@ This implementation complies with the LOLA specification across all major requir
 
 ### 1. Discovery and Authentication ✅
 
-**Specification Requirement**: "Source server advertises an OAuth endpoint for authorizing account portability"
+**Specification Requirement** (LOLA §4.2): "Supporting servers MUST provide their portability authorization endpoint in Actor objects … advertised under `endpoints.oauthMigrationEndpoint` … parallel to `oauthAuthorizationEndpoint`."
 
-**Implementation**: 
-- Actor objects include `accountPortabilityOauth` field when accessed with portability scope
+**Implementation**:
+- Actor objects always expose the public `endpoints` object carrying `oauthMigrationEndpoint` (and the parallel `oauthAuthorizationEndpoint`) — present even on unauthenticated responses
 - OAuth endpoint URL dynamically built based on current server configuration
 - Proper `activitypub_account_portability` scope implementation
 - State parameter validation for CSRF protection
 
-**Note**: This implementation uses Actor-based discovery (via the `accountPortabilityOauth` field) rather than RFC8414 `.well-known` metadata endpoints. The LOLA specification supports both approaches.
+**Note**: This implementation supports **both** discovery paths the spec allows, and both are implemented. Actor-based discovery uses `endpoints.oauthMigrationEndpoint` (LOLA §4.2). RFC8414 `.well-known` discovery advertises the same authorization endpoint as the `activitypub_account_portability` URL string (LOLA §4.1) — see [LOLA Discovery](lola-discovery.md). The legacy top-level `accountPortabilityOauth` field has been removed.
 
 ```json
 {
@@ -1137,7 +1168,10 @@ This implementation complies with the LOLA specification across all major requir
     "https://swicg.github.io/activitypub-data-portability/lola.jsonld"
   ],
   "type": "Person",
-  "accountPortabilityOauth": "https://example.com/oauth/authorize/"
+  "endpoints": {
+    "oauthAuthorizationEndpoint": "https://example.com/oauth/authorize/",
+    "oauthMigrationEndpoint": "https://example.com/oauth/authorize/"
+  }
 }
 ```
 
@@ -1183,19 +1217,23 @@ if not auth_context or not auth_context.get('has_portability_scope'):
 
 ### 4. Discovery Collections ✅
 
-**Specification Requirement**: "Content can be copied from a new content collection endpoint"
+**Specification Requirement** (LOLA §4.4): the authenticated Actor advertises a `migration` object whose members (`outbox`, `content`, `following`, `blocked`) are the dedicated migration-collection routes.
 
 **Implementation**:
-- `content` endpoint URL provided in authenticated Actor responses
-- `blocked` endpoint for block list access
-- `migration` endpoint pointing to outbox for activity migration
-- Following/followers collections maintained per ActivityPub spec
+- `migration` is an **object** (not a single URL) pointing at the four dedicated `actors/<pk>/migration/...` routes
+- `liked` and `followers` are regular **Actor collections**, not migration collections, and are advertised at the top level — never inside `migration`
+- These fields appear only on responses carrying a valid portability-scoped token
 
 ```json
 {
-  "content": "https://example.com/actors/1/content",
+  "liked": "https://example.com/actors/1/liked",
   "blocked": "https://example.com/actors/1/blocked",
-  "migration": "https://example.com/actors/1/outbox"
+  "migration": {
+    "outbox": "https://example.com/actors/1/migration/outbox",
+    "content": "https://example.com/actors/1/migration/content",
+    "following": "https://example.com/actors/1/migration/following",
+    "blocked": "https://example.com/actors/1/migration/blocked"
+  }
 }
 ```
 

--- a/docs/lola-discovery.md
+++ b/docs/lola-discovery.md
@@ -332,12 +332,12 @@ curl -s https://localhost:8000/.well-known/oauth-authorization-server | \
 
 ## Integration with LOLA
 
-### Actor-based Discovery (Alternative)
+### Actor-based Discovery (Required — LOLA §4.2)
 
-While this implementation focuses on RFC8414 discovery, LOLA also supports Actor-based discovery. Both methods can coexist:
+This implementation supports both discovery paths and they coexist, but they are not equally optional. RFC8414 `.well-known` discovery is a SHOULD (LOLA §4.1); advertising the endpoint on the Actor is a MUST (LOLA §4.2). After authorization, the Actor fetched with the portability token additionally advertises the scope-gated `migration` object (see [LOLA Authentication](lola-authentication.md)).
 
-**RFC8414 Discovery**: `/.well-known/oauth-authorization-server`\
-**Actor Discovery**: `endpoints.oauthMigrationEndpoint` field in Actor objects
+**RFC8414 Discovery** (SHOULD): `/.well-known/oauth-authorization-server`\
+**Actor Discovery** (MUST): `endpoints.oauthMigrationEndpoint` field in Actor objects
 
 Supporting servers MUST advertise their portability authorization endpoint in Actor objects under
 `endpoints.oauthMigrationEndpoint`, in parallel with `endpoints.oauthAuthorizationEndpoint`:
@@ -357,8 +357,8 @@ Supporting servers MUST advertise their portability authorization endpoint in Ac
 ### Discovery Preference
 
 Destination servers can use either method:
-1. **RFC8414 first**: Standard OAuth discovery
-2. **Actor fallback**: If `.well-known` is not available
+1. **Actor discovery** (always available): `endpoints.oauthMigrationEndpoint` is advertised on every Actor (MUST)
+2. **RFC8414 discovery**: the `.well-known` document, when the source publishes one (SHOULD)
 3. **Validation**: Cross-reference both sources
 
 ### LOLA Workflow Integration

--- a/docs/oauth/phase-3-authorization-code-and-callback-handling.md
+++ b/docs/oauth/phase-3-authorization-code-and-callback-handling.md
@@ -141,9 +141,8 @@ This testbed is **source server**, so it is responsible for the other half of th
 
 **Location**: `testbed/core/oauth/views.py` — `PortabilityAuthorizationView`
 
-- `PortabilityAuthorizationView` subclasses django-oauth-toolkit's
-- `AuthorizationView` and is wired ahead of the `oauth2_provider` URL include in
-- `testbed/urls.py`. DOT already produces `code` and `state`; this subclass only appends `activitypub_actor` to the redirect's `Location` header:
+`PortabilityAuthorizationView` subclasses django-oauth-toolkit's `AuthorizationView` and is wired ahead of the `oauth2_provider` URL include in `testbed/urls.py`.
+DOT already produces `code` and `state`; this subclass only appends `activitypub_actor` to the redirect's `Location` header:
 
 ```python
 class PortabilityAuthorizationView(AuthorizationView):

--- a/docs/oauth/phase-3-authorization-code-and-callback-handling.md
+++ b/docs/oauth/phase-3-authorization-code-and-callback-handling.md
@@ -13,6 +13,7 @@ In the context of LOLA portability, this phase confirms user intent to transfer 
 - Deliver a **temporary, one-time-use authorization code** securely to the Destination Service.
 - Maintain security integrity by validating the **state parameter** to prevent CSRF attacks.
 - Ensure the code is properly **bound** to the specific client, scope, and redirect URI.
+- For LOLA portability authorizations, include **`activitypub_actor`** in the approval redirect so the destination learns exactly which source Actor granted access.
 - Provide a clear **callback handling process** that prepares for token exchange.
 - Handle **success and error scenarios** gracefully for the end-user and client application.
 
@@ -41,10 +42,16 @@ This phase begins **after** the user has consented to the data transfer (Phase 2
 After generating the authorization code:
 
 - The Source Service **redirects the user’s browser** to the pre-registered redirect_uri on the Destination Service.
-- The **authorization code** and the original **state parameter** are appended as query parameters, for example:
+- The **authorization code** and the original **state parameter** are appended as query parameters. For a standard OAuth authorization:
 
 ```
 https://destination.com/callback?code=abc123&state=xyz789
+```
+
+- For a **LOLA portability authorization** (a request that carried the `activitypub_account_portability` scope), the Source Service additionally appends **`activitypub_actor`** — the absolute URL of the source Actor that granted access (LOLA §5.3):
+
+```
+https://destination.com/callback?code=abc123&state=xyz789&activitypub_actor=https%3A%2F%2Fsource.example%2Fapi%2Factors%2F1%2F
 ```
 
 This preserves the security context established earlier and signals the Destination Service to begin callback handling.
@@ -124,6 +131,43 @@ def validate_state_from_session(request, state):
     # Constant-time comparison
     return secrets.compare_digest(stored_state, state)
 ```
+
+### Source-Server Response: Appending `activitypub_actor` (LOLA §5.3)
+
+This testbed is **source server**, so it is responsible for the other half of the redirect: emitting the `activitypub_actor` parameter when it approves a portability authorization.
+
+> LOLA §5.3: "If authorization is approved, the source redirects back with: `code`, `state`, `activitypub_actor`."
+> "The destination MUST use the Actor ID returned in `activitypub_actor`, even if it differs from what the user originally supplied."
+
+**Location**: `testbed/core/oauth/views.py` — `PortabilityAuthorizationView`
+
+- `PortabilityAuthorizationView` subclasses django-oauth-toolkit's
+- `AuthorizationView` and is wired ahead of the `oauth2_provider` URL include in
+- `testbed/urls.py`. DOT already produces `code` and `state`; this subclass only appends `activitypub_actor` to the redirect's `Location` header:
+
+```python
+class PortabilityAuthorizationView(AuthorizationView):
+    def form_valid(self, form):
+        # POST approval path. Resolve the source actor BEFORE super() so we
+        # never append on a failure path, then let DOT build the redirect.
+        scopes = form.cleaned_data.get("scope") or ""
+        actor = self._prepare_actor_binding(scopes)
+        response = super().form_valid(form)
+        if actor is not None:
+            self._append_actor_to_redirect(response, actor)
+        return response
+```
+
+Key behavior, mirrored exactly by the code:
+
+- **Scope-gated.** `_prepare_actor_binding` returns `None` for any authorization that did not request `activitypub_account_portability`, so regular OAuth flows are completely unaffected.
+- **Approved redirects only.** `_append_actor_to_redirect` parses DOT's `Location` header and appends `activitypub_actor` only when `code` is present. Denial and error redirects are left untouched.
+- **Canonical Actor URL.** The appended value is built with `build_actor_id`, so it is byte-identical to the Actor's JSON-LD `id` and to the actor the issued token is bound to (see [Token-to-Actor Binding](../lola-authentication.md#token-to-actor-binding-lola-section-5)).
+- **Redirect omission vs. access denial.** If no source Actor resolves for the approving user, the view logs a warning and omits the parameter rather than blocking the redirect;
+the matching token, however, is never issued unbound (the validator fails closed at issuance).
+
+Resolution of the approving user's source Actor is deterministic (`Actor.objects.get(user=user, role=ROLE_SOURCE)`), and the validator that
+binds the token performs the same lookup independently, which is what keeps the redirect Actor and the token-bound Actor aligned.
 
 ## Security Considerations
 


### PR DESCRIPTION
Closes #261 

Documentation-only closeout of previous PRs.
It just makes sure that codebase is align with revised draft and new features implemented.