### PR TITLE
Remove ?auth_token= URL auth path; header + demo-scoped session only

### DIFF
--- a/docs/lola-authentication.md
+++ b/docs/lola-authentication.md
@@ -838,7 +838,7 @@ The implementation includes comprehensive test coverage across multiple test fil
 
 **5. Technical Implementation**
 - `test_content_type_headers_set_correctly()` - HTTP header validation
-- `TestOptionalAuthenticationEnvironmentScoping` - session-auth path and token-validation
+- `TestOptionalAuthenticationSessionPath` - session-auth path and token-validation
 
 ### Test Fixtures and Factories
 

--- a/docs/lola-authentication.md
+++ b/docs/lola-authentication.md
@@ -109,7 +109,7 @@ def get_user_application(user, request=None):
 
 ## OptionalOAuth2Authentication Class
 
-The core of the LOLA authentication system is the `OptionalOAuth2Authentication` class located in `testbed/core/utils/authentication.py`.
+The core of the LOLA authentication system is the `OptionalOAuth2Authentication` class located in `testbed/core/oauth/authentication.py`.
 
 ### Purpose
 
@@ -117,24 +117,26 @@ This authentication class enables endpoints to function in two distinct modes:
 1. **Unauthenticated Mode**: Standard ActivityPub federation (public data only)
 2. **Authenticated Mode**: LOLA account portability with enhanced data access
 
-### Three-Tier Authentication Chain
+### Two-Path Authentication Chain
 
-The authentication system implements intelligent prioritization across three authentication methods:
+The class accepts a portability token two ways, tried in priority order:
 
-**Tier 1: Authorization Header (Production)**
+**Path 1: Authorization Header (normative)**
 - Standard OAuth 2.0 RFC 6750 Bearer token authentication
+- The only path that is part of the LOLA source-server contract — a real
+  destination always uses this
 - Used by external ActivityPub servers and production API clients
-- Most explicit authentication method (highest priority)
+- Always enabled
 
-**Tier 2: URL Parameter (Testing)**
-- `?auth_token=TOKEN` parameter for development and testing convenience
-- Enables simple HTML link-based testing without JavaScript
-- Visible authentication method for debugging
-
-**Tier 3: Session Storage (Demo Enhancement)**
-- Automatic authentication using tokens stored in Django sessions
-- Seamless demo experience after successful OAuth completion
-- Implicit authentication method (lowest priority)
+**Path 2: Session-stored token (NON-NORMATIVE demo convenience)**
+- Automatic authentication using a token the demo token-exchange flow stored in
+  the Django session (`store_token_in_session`)
+- Powers the seamless "Session Authentication Active" demo, where the browser
+  opens the LOLA collection links without re-sending a header
+- **Demo-scoped by construction** (no setting flag): only the demo flow ever
+  populates the session, the token is cookie-bound (never in a URL), and it is
+  re-validated against the DB each request; `?public_only=true` suppresses it
+  for the public-vs-gated comparison
 
 ### Authentication Method Implementation
 
@@ -143,33 +145,29 @@ def authenticate(self, request):
     # Initialize authentication flags
     request.is_oauth_authenticated = False
     request.has_portability_scope = False
-    
+
     try:
-        # Tier 1: Authorization header (production)
+        # 1. Normative path: Authorization: Bearer header
         result = super().authenticate(request)
-        
-        # Tier 2: URL parameter (testing)
-        if result is None:
-            result = self._authenticate_with_url_token(request)
-        
-        # Tier 3: Session storage (demo)
+
+        # 2. Demo fallback: session-stored token (demo-scoped; see _try_session_auth)
         if result is None:
             result = self._try_session_auth(request)
-        
+
         # Process successful authentication
         if result is not None:
             user, token = result
             request.is_oauth_authenticated = True
-            
+
             if self._has_portability_scope(token):
                 request.has_portability_scope = True
-            
+
             return user, token
-            
+
     except exceptions.AuthenticationFailed:
         # Graceful degradation: continue as unauthenticated
         pass
-    
+
     return None
 ```
 
@@ -177,7 +175,7 @@ def authenticate(self, request):
 
 - **Optional Authentication**: Unlike standard OAuth2Authentication, this doesn't fail requests without tokens
 - **Scope Validation**: Checks for `activitypub_account_portability` scope
-- **Multiple Auth Methods**: Supports header, URL parameter, and session authentication
+- **Two Auth Paths**: the normative `Authorization` header plus a demo-scoped session path
 - **Request Flag Setting**: Adds authentication status flags to request objects
 - **Graceful Error Handling**: Invalid/expired tokens fall back to unauthenticated behavior
 
@@ -206,36 +204,25 @@ After authentication, the following flags are available on request objects:
 
 ### Authentication Methods
 
-#### 1. Authorization Header (Production)
+#### 1. Authorization Header (normative)
 ```http
 GET /api/actors/1/ HTTP/1.1
 Authorization: Bearer your-oauth-token-here
 ```
 
 **Implementation**: Standard OAuth 2.0 RFC 6750 Bearer token authentication
-**Use Cases**: External ActivityPub servers, production API clients, federation
-**Priority**: Highest (Tier 1)
+**Use Cases**: External ActivityPub servers, real destination implementations, federation
+**Priority**: Highest (Path 1) — the only path in the source-server contract
 
-#### 2. URL Parameter (Testing)
-```http
-GET /api/actors/1/?auth_token=your-oauth-token-here HTTP/1.1
-```
-
-**Implementation**: `_authenticate_with_url_token()` method validates URL parameter against OAuth database
-**Use Cases**: Development testing, debugging, educational demonstrations
-**Priority**: Medium (Tier 2)
-
-The URL parameter method enables simple `<a>` link testing in HTML templates without JavaScript.
-
-#### 3. Session Storage (Demo Enhancement)
+#### 2. Session Storage (NON-NORMATIVE demo convenience)
 ```http
 GET /api/actors/1/ HTTP/1.1
 Cookie: sessionid=abc123...
 ```
 
-**Implementation**: `_try_session_auth()` method validates session-stored OAuth tokens
+**Implementation**: `_try_session_auth()` validates a token the demo token-exchange flow stored in the session
 **Use Cases**: Seamless demo experience, community education, conference presentations
-**Priority**: Lowest (Tier 3)
+**Priority**: Fallback (Path 2). Demo-scoped by construction; no setting flag
 
 **Session Authentication Flow**:
 1. User completes OAuth authorization and token exchange
@@ -326,10 +313,12 @@ GET /api/actors/1/?public_only=true
 GET /api/actors/1/
 ```
 
-**Template Integration**:
+**Template Integration**: the authenticated links authenticate via the session
+(set during token exchange), so they carry no token in the URL; the public
+comparison links add `?public_only=true` to suppress session auth.
 ```html
-<!-- Authenticated links -->
-<a href="/api/actors/{{ actor.pk }}/?format=json&auth_token={{ token }}" target="_blank">
+<!-- Authenticated links (session-based; no token in the URL) -->
+<a href="/api/actors/{{ actor.pk }}/?format=json" target="_blank">
   Details (with LOLA fields)
 </a>
 
@@ -343,23 +332,19 @@ GET /api/actors/1/
 
 ### Error Handling
 
-The class handles various authentication scenarios across all three tiers:
+The class handles various authentication scenarios across both paths:
 
-**Authorization Header (Tier 1):**
+**Authorization Header (Path 1):**
 - **Invalid tokens**: Continue as unauthenticated
 - **Expired tokens**: Continue as unauthenticated  
 - **Malformed headers**: Continue as unauthenticated
 
-**URL Parameter (Tier 2):**
-- **Invalid auth_token parameter**: Continue as unauthenticated
-- **Missing token in database**: Continue as unauthenticated
-
-**Session Storage (Tier 3):**
+**Session Storage (Path 2):**
 - **Expired session tokens**: Automatically cleared and continue as unauthenticated
 - **Missing session data**: Continue as unauthenticated
 - **public_only parameter**: Bypass session auth for comparison demos
 
-**Scope Validation (All Tiers):**
+**Scope Validation (both paths):**
 - **Missing scope**: Authenticated but without portability access
 - **Malformed scope**: Continue as unauthenticated
 
@@ -440,9 +425,9 @@ runs two layers:
   binding rows, and requests without a URL pk all return 403 `actor_mismatch`
   (fail closed).
 
-The binding check covers all three `OptionalOAuth2Authentication` paths
-(Authorization header, `?auth_token=` URL parameter, session) because all
-three set `request.auth` to the same `AccessToken` instance.
+The binding check covers both `OptionalOAuth2Authentication` paths
+(Authorization header and session) because both set `request.auth` to the same
+`AccessToken` instance.
 
 ### Endpoints Enforcing Binding
 
@@ -772,31 +757,33 @@ The enhanced OAuth token exchange template (`testbed/core/templates/oauth_token_
 - Includes troubleshooting guides for "invalid_client" and other errors
 
 #### 2. Interactive LOLA Testing Links
-When a token is successfully obtained, the interface provides direct HTML links for testing LOLA authentication using URL parameter authentication:
+When a token is successfully obtained, it is stored in the session, so the
+interface provides direct HTML links that authenticate via **session auth** — no
+token is placed in any URL:
 
 ```html
-<!-- LOLA-authenticated links -->
-<a href="/api/actors/{{ source_actor.pk }}/?format=json&auth_token={{ token_response.access_token }}" target="_blank">
+<!-- LOLA-authenticated links (session-based; the token is never in the URL) -->
+<a href="/api/actors/{{ source_actor.pk }}/?format=json" target="_blank">
   Details (with LOLA fields)
 </a>
 
-<a href="/api/actors/{{ source_actor.pk }}/outbox?format=json&auth_token={{ token_response.access_token }}" target="_blank">
+<a href="/api/actors/{{ source_actor.pk }}/outbox?format=json" target="_blank">
   Outbox (all activities)
 </a>
 
-<!-- Compare with public versions -->
-<a href="/api/actors/{{ source_actor.pk }}/?format=json" target="_blank">
+<!-- Compare with public versions (suppress session auth) -->
+<a href="/api/actors/{{ source_actor.pk }}/?format=json&public_only=true" target="_blank">
   Details (basic ActivityPub)
 </a>
 
-<a href="/api/actors/{{ source_actor.pk }}/outbox?format=json" target="_blank">
+<a href="/api/actors/{{ source_actor.pk }}/outbox?format=json&public_only=true" target="_blank">
   Outbox (public only)
 </a>
 ```
 
 **Key Features:**
-- Uses URL parameter authentication (`?auth_token=...`) for easy testing without JavaScript
-- Provides side-by-side comparison between LOLA-authenticated and public responses
+- Uses session authentication (token stored during token exchange); the token never appears in a URL
+- Provides side-by-side comparison between LOLA-authenticated and public (`?public_only=true`) responses
 - Opens results in new tabs for easy comparison
 - Works directly in any browser without additional tools
 
@@ -849,9 +836,9 @@ The implementation includes comprehensive test coverage across multiple test fil
 - `test_invalid_token_graceful_degradation()` - Invalid token handling
 - `test_malformed_authorization_header_handling()` - Malformed header tolerance with parameterized test cases
 
-**5. Technical Implementation (2 tests)**
-- `test_actor_detail_url_parameter_authentication()` - URL parameter authentication method
+**5. Technical Implementation**
 - `test_content_type_headers_set_correctly()` - HTTP header validation
+- `TestOptionalAuthenticationEnvironmentScoping` - session-auth path and token-validation
 
 ### Test Fixtures and Factories
 
@@ -1291,7 +1278,7 @@ This maintains semantic compatibility while adding LOLA-specific vocabularies.
 ### 5. **Testing and Development Experience**
 - Comprehensive test coverage across all authentication states
 - Interactive testing interface for manual verification
-- URL parameter authentication for easy template-based testing
+- Session-based authentication for easy template-based testing (no token in the URL)
 - Visual highlighting of LOLA-specific fields in responses
 
 ## Related Documentation

--- a/testbed/core/oauth/authentication.py
+++ b/testbed/core/oauth/authentication.py
@@ -7,7 +7,6 @@ ActivityPub federation and LOLA account portability requirements.
 
 import logging
 
-from django.conf import settings
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from rest_framework import exceptions
 
@@ -35,14 +34,15 @@ class OptionalOAuth2Authentication(OAuth2Authentication):
         Attempt to authenticate the request using OAuth2 with multiple methods.
 
         Authentication priority:
-        1. Authorization header - the only normative LOLA path (always enabled)
-        2. Session-stored token - gated by LOLA_ALLOW_SESSION_TOKEN_AUTH
+        1. Authorization header - the only normative LOLA path
+        2. Session-stored token - non-normative demo convenience
 
-        Path 2 is a non-normative testbed convenience that exists because this testbed doubles
-        as a destination-side demo tool: after the demo token-exchange flow stores a token in
-        the session, the browser can browse the LOLA collections without re-sending a header.
-        
-        It is NOT part of the LOLA source-server contract and is gated inside its own helper.
+        Path 2 exists because this testbed doubles as a destination-side demo tool: after the
+        demo token-exchange flow stores a token in the session, the browser can browse the LOLA
+        collections without re-sending a header.
+
+        It is NOT part of the LOLA source-server contract. It is demo-scoped by construction.
+        Only the demo flow populates the session, it is cookie-bound, and it is suppressed by ?public_only.
         See docs/lola-authentication.md.
 
         Both enabled paths produce the same (user, token) shape and set
@@ -110,28 +110,19 @@ class OptionalOAuth2Authentication(OAuth2Authentication):
         The token is re-validated against the DB each request (handles revocation) and expired
         tokens are cleared from the session.
 
-        Supports the 'public_only' query parameter to suppress session auth for
-        the demo's public-vs-gated comparison.
+        Demo-scoped by construction: only the demo token-exchange flow populates the session, the
+        token is cookie-bound (never in a URL), and ?public_only suppresses it.
 
         Args:
             request: The HTTP request object
 
         Returns:
-            A tuple of (user, token) if authentication succeeds, None otherwise
-            (including when this path is disabled for the environment).
+            A tuple of (user, token) if authentication succeeds, None otherwise.
         """
         from testbed.core.oauth.utils import (
             clear_token_from_session,
             get_token_from_session,
         )
-
-        # Skip entirely unless this environment opts in.
-        if not getattr(settings, "LOLA_ALLOW_SESSION_TOKEN_AUTH", False):
-            logger.debug(
-                "Session auth skipped: LOLA_ALLOW_SESSION_TOKEN_AUTH disabled "
-                "for this environment"
-            )
-            return None
 
         # public_only forces the unauthenticated view for demo comparison.
         if request.GET.get("public_only"):

--- a/testbed/core/oauth/authentication.py
+++ b/testbed/core/oauth/authentication.py
@@ -6,6 +6,8 @@ ActivityPub federation and LOLA account portability requirements.
 """
 
 import logging
+
+from django.conf import settings
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from rest_framework import exceptions
 
@@ -33,17 +35,20 @@ class OptionalOAuth2Authentication(OAuth2Authentication):
         Attempt to authenticate the request using OAuth2 with multiple methods.
 
         Authentication priority:
-        1. Authorization header (production - the normative LOLA path)
-        2. URL parameter (?auth_token=) - developer testing convenience only
-        3. Session storage - demo enhancement only
+        1. Authorization header - the only normative LOLA path (always enabled)
+        2. Session-stored token - gated by LOLA_ALLOW_SESSION_TOKEN_AUTH
 
-        Paths 2 and 3 are developer/demo conveniences that exist because this
-        testbed doubles as a destination-side demo tool. They are NOT part of the
-        normative LOLA source-server contract. See docs/lola-authentication.md.
+        Path 2 is a non-normative testbed convenience that exists because this testbed doubles
+        as a destination-side demo tool: after the demo token-exchange flow stores a token in
+        the session, the browser can browse the LOLA collections without re-sending a header.
+        
+        It is NOT part of the LOLA source-server contract and is gated inside its own helper.
+        See docs/lola-authentication.md.
 
-        All three paths produce the same (user, token) shape and set request.auth
-        to the AccessToken instance. The actor binding check in validate_lola_access()
-        operates on request.auth and therefore covers all three paths uniformly.
+        Both enabled paths produce the same (user, token) shape and set
+        request.auth to the AccessToken instance. The actor binding check in
+        validate_lola_access() operates on request.auth and therefore covers
+        every path uniformly.
 
         If authentication succeeds, checks if the token has the portability scope.
         If authentication fails, allows the request to continue as unauthenticated.
@@ -59,17 +64,13 @@ class OptionalOAuth2Authentication(OAuth2Authentication):
         request.has_portability_scope = False
         
         try:
-            # 1. First try standard Authorization header authentication (PRODUCTION)
+            # 1. Normative path: standard Authorization: Bearer header auth
             result = super().authenticate(request)
-            
-            # 2. If header auth failed, try URL parameter auth (TESTING)
-            if result is None:
-                result = self._authenticate_with_url_token(request)
-            
-            # 3. NEW: If URL auth failed, try session auth (DEMO ENHANCEMENT)
+
+            # 2. Demo fallback: session-stored token
             if result is None:
                 result = self._try_session_auth(request)
-            
+
             if result is not None:
                 user, token = result
                 
@@ -100,102 +101,85 @@ class OptionalOAuth2Authentication(OAuth2Authentication):
         # This allows the request to continue as unauthenticated rather than failing
         return None
     
-    def _authenticate_with_url_token(self, request):
-        """
-        Try to authenticate using token from URL parameter (for LOLA testing convenience).
-        
-        Checks for 'auth_token' in URL parameters and validates it as an OAuth token.
-        This enables simple <a> links in templates for testing LOLA functionality.
-        
-        Args:
-            request: The HTTP request object
-            
-        Returns:
-            A tuple of (user, token) if authentication succeeds, None otherwise
-        """
-        from oauth2_provider.models import AccessToken
-        
-        # Get token from URL parameter
-        token_string = request.GET.get('auth_token')
-        if not token_string:
-            return None
-            
-        try:
-            # Look up the token in the database
-            access_token = AccessToken.objects.select_related('user', 'application').get(
-                token=token_string
-            )
-            
-            # Check if token is valid (not expired)
-            if access_token.is_valid():
-                logger.debug(f"URL parameter authentication successful for user: {access_token.user.username}")
-                return access_token.user, access_token
-            else:
-                logger.debug("URL parameter token is expired or invalid")
-                return None
-                
-        except AccessToken.DoesNotExist:
-            logger.debug("URL parameter token not found in database")
-            return None
-        except Exception as e:
-            logger.debug(f"Error during URL parameter authentication: {str(e)}")
-            return None
-
     def _try_session_auth(self, request):
         """
-        Try to authenticate using token stored in session (demo enhancement).
-        
-        This provides seamless authentication after successful OAuth token exchange,
-        eliminating the need for manual token handling in demo workflows. The method
-        validates session tokens against the database to ensure they haven't been
-        revoked and handles automatic cleanup of expired tokens.
-        
-        Supports 'public_only' parameter to disable session auth for comparison demos.
-        
+        Try to authenticate using a token stored in the Django session.
+
+        NON-NORMATIVE demo path. After the demo token-exchange flow stores the access token in the
+        session (store_token_in_session), later requests from that browser session authenticate automatically.
+        The token is re-validated against the DB each request (handles revocation) and expired
+        tokens are cleared from the session.
+
+        Supports the 'public_only' query parameter to suppress session auth for
+        the demo's public-vs-gated comparison.
+
         Args:
             request: The HTTP request object
-            
+
         Returns:
             A tuple of (user, token) if authentication succeeds, None otherwise
+            (including when this path is disabled for the environment).
         """
-        from oauth2_provider.models import AccessToken
-        from testbed.core.oauth.utils import get_token_from_session, clear_token_from_session
-        
-        # Check if public_only parameter is set (for demo comparison)
-        if request.GET.get('public_only'):
-            logger.debug("public_only parameter detected - skipping session authentication")
+        from testbed.core.oauth.utils import (
+            clear_token_from_session,
+            get_token_from_session,
+        )
+
+        # Skip entirely unless this environment opts in.
+        if not getattr(settings, "LOLA_ALLOW_SESSION_TOKEN_AUTH", False):
+            logger.debug(
+                "Session auth skipped: LOLA_ALLOW_SESSION_TOKEN_AUTH disabled "
+                "for this environment"
+            )
             return None
-        
-        # Get token from session (this handles expiration checking)
+
+        # public_only forces the unauthenticated view for demo comparison.
+        if request.GET.get("public_only"):
+            logger.debug("public_only set - skipping session authentication")
+            return None
+
+        # get_token_from_session handles session-side expiry checking.
         token_string = get_token_from_session(request)
         if not token_string:
             return None
-            
-        try:
-            # Look up the token in the database to ensure it's still valid
-            # (handles cases where token was revoked but still in session)
-            access_token = AccessToken.objects.select_related('user', 'application').get(
-                token=token_string
-            )
-            
-            # Verify token is still valid (handles revocation, etc.)
-            if access_token.is_valid():
-                logger.debug(f"Session authentication successful for user: {access_token.user.username}")
-                return access_token.user, access_token
-            else:
-                # Token invalid - clear from session to prevent future attempts
-                clear_token_from_session(request)
-                logger.debug("Session token invalid, cleared from session")
-                return None
-                
-        except AccessToken.DoesNotExist:
-            # Token not found in database - clear from session
-            logger.debug("Session token not found in database, clearing from session")
+
+        result = self._resolve_valid_access_token(token_string)
+        if result is None:
+            # Token missing/expired/revoked in the DB: clear it from the session
+            # so we don't keep retrying a dead token on every request.
             clear_token_from_session(request)
+            logger.debug("Session token invalid - cleared from session")
             return None
-        except Exception as e:
-            logger.debug(f"Error during session authentication: {str(e)}")
+
+        logger.debug(
+            "Session authentication successful for user: %s", result[0].username
+        )
+        return result
+
+    def _resolve_valid_access_token(self, token_string):
+        """
+        Look up an AccessToken by its raw string and return (user, token) if it
+        exists and is currently valid (not expired), else None.
+
+        Validation step for the session path (_try_session_auth): turns the token
+        string read from the session into the (user, AccessToken) pair the auth
+        contract expects, rejecting unknown or expired tokens. 
+        
+        Returns None for a missing token, so callers fail closed to unauthenticated; unexpected
+        lookup errors propagate to authenticate(), whose broad handler degrades the request to unauthenticated.
+        """
+        from oauth2_provider.models import AccessToken
+
+        try:
+            access_token = AccessToken.objects.select_related(
+                "user", "application"
+            ).get(token=token_string)
+        except AccessToken.DoesNotExist:
             return None
+
+        if access_token.is_valid():
+            return access_token.user, access_token
+        return None
     
     def _has_portability_scope(self, token):
         """

--- a/testbed/core/oauth/authentication.py
+++ b/testbed/core/oauth/authentication.py
@@ -156,8 +156,9 @@ class OptionalOAuth2Authentication(OAuth2Authentication):
         string read from the session into the (user, AccessToken) pair the auth
         contract expects, rejecting unknown or expired tokens. 
         
-        Returns None for a missing token, so callers fail closed to unauthenticated; unexpected
-        lookup errors propagate to authenticate(), whose broad handler degrades the request to unauthenticated.
+        Returns None for a missing or invalid (unknown/expired) token, so callers fail closed to
+        unauthenticated; unexpected lookup errors propagate to authenticate(), whose broad handler
+        degrades the request to unauthenticated.
         """
         from oauth2_provider.models import AccessToken
 

--- a/testbed/core/templates/oauth_token_exchange.html
+++ b/testbed/core/templates/oauth_token_exchange.html
@@ -127,12 +127,16 @@
         <h3>🧪 Test LOLA ActivityPub Endpoints</h3>
         <p>Your <strong>Source Actor</strong> with LOLA portability scope:</p>
         
+        {# Authenticated links rely on session auth: the token was stored in the  #}
+        {# session during token exchange, so these requests authenticate via the  #}
+        {# session cookie -- the token is never placed in a URL. The matching     #}
+        {# ?public_only=true links below suppress session auth for comparison.    #}
         <div class="actor">
           <div>Username: {{ source_actor.username }}</div>
-          <div><a href="/api/actors/{{ source_actor.pk }}/?format=json&auth_token={{ token_response.access_token }}" target="_blank">Details (with LOLA fields)</a></div>
-          <div><a href="/api/actors/{{ source_actor.pk }}/outbox?format=json&auth_token={{ token_response.access_token }}" target="_blank">Outbox (all activities)</a></div>
-          <div><a href="/api/actors/{{ source_actor.pk }}/following/?format=json&auth_token={{ token_response.access_token }}" target="_blank">Following Collection (public)</a></div>
-          <div><a href="/api/actors/{{ source_actor.pk }}/followers/?format=json&auth_token={{ token_response.access_token }}" target="_blank">Followers Collection (LOLA-gated)</a></div>
+          <div><a href="/api/actors/{{ source_actor.pk }}/?format=json" target="_blank">Details (with LOLA fields)</a></div>
+          <div><a href="/api/actors/{{ source_actor.pk }}/outbox?format=json" target="_blank">Outbox (all activities)</a></div>
+          <div><a href="/api/actors/{{ source_actor.pk }}/following/?format=json" target="_blank">Following Collection (public)</a></div>
+          <div><a href="/api/actors/{{ source_actor.pk }}/followers/?format=json" target="_blank">Followers Collection (LOLA-gated)</a></div>
         </div>
         
         <p><strong>Compare with public versions (no authentication):</strong></p>

--- a/testbed/core/tests/test_api.py
+++ b/testbed/core/tests/test_api.py
@@ -2,7 +2,7 @@ import pytest
 from rest_framework.test import APIClient
 from rest_framework import status
 from django.urls import reverse
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 from django.contrib.auth import get_user_model
 from oauth2_provider.models import Application, AccessToken
 from testbed.core.models import Actor, Following, Followers
@@ -19,6 +19,8 @@ from testbed.core.json_ld_utils import (
     build_actor_id,
     build_outbox_id,
 )
+from testbed.core.oauth.authentication import OptionalOAuth2Authentication
+from testbed.core.oauth.utils import store_token_in_session
 
 User = get_user_model()
 
@@ -84,22 +86,7 @@ Edge case tests for LOLA authentication.
 These tests focus on specific edge cases: URL params, outbox filtering, error handling, headers.
 """
 class TestLOLAAuthenticationAPI:
-    
-    # Test that URL parameter authentication works for LOLA testing
-    @pytest.mark.django_db
-    def test_actor_detail_url_parameter_authentication(self):
-        actor = create_isolated_actor("url_param_test")
-        lola_token = AccessTokenFactory(lola_scope=True)
-        client = APIClient()
-        
-        # Use auth_token URL parameter instead of Authorization header
-        url = reverse("actor-detail", kwargs={"pk": actor.id})
-        response = client.get(f"{url}?auth_token={lola_token.token}")
-        
-        assert response.status_code == status.HTTP_200_OK
-        # Should have migration field (proves URL parameter auth worked)
-        assert "migration" in response.data
-    
+
     # Test that outbox shows different content based on authentication
     @pytest.mark.django_db
     def test_outbox_content_filtering_by_authentication(self, mock_request):
@@ -469,3 +456,44 @@ class TestLOLACollectionDiscovery:
                 # Public and basic OAuth should not see collection URLs
                 assert "following" not in data
                 assert "followers" not in data
+
+
+# OptionalOAuth2Authentication session-auth gate
+
+"""
+Auth class has two paths:
+Normative Authorization: Bearer header (covered by the existing header tests in this file and by test_token_actor_binding.py)
+and the NON-NORMATIVE session-stored token path, gated by LOLA_ALLOW_SESSION_TOKEN_AUTH.
+"""
+class TestOptionalAuthenticationEnvironmentScoping:
+
+    # With the flag off, session auth is skipped before any session read
+    @pytest.mark.django_db
+    @override_settings(LOLA_ALLOW_SESSION_TOKEN_AUTH=False)
+    def test_session_path_disabled_by_environment(self):
+        request = RequestFactory().get("/api/actors/1/")
+        request.session = {}  # would carry a token if the path were enabled
+
+        result = OptionalOAuth2Authentication()._try_session_auth(request)
+        assert result is None
+
+    # With the flag on, a valid session-stored token authenticates
+    @pytest.mark.django_db
+    @override_settings(LOLA_ALLOW_SESSION_TOKEN_AUTH=True)
+    def test_session_path_enabled_authenticates(self):
+        token = AccessTokenFactory(lola_scope=True)
+        request = RequestFactory().get("/api/actors/1/")
+        request.session = {}
+        store_token_in_session(
+            request, {"access_token": token.token, "scope": token.scope}
+        )
+
+        result = OptionalOAuth2Authentication()._try_session_auth(request)
+        assert result == (token.user, token)
+
+    # An expired token is rejected by the session path's validation step
+    @pytest.mark.django_db
+    def test_resolve_valid_access_token_rejects_expired(self):
+        token = AccessTokenFactory(lola_scope=True, expired=True)
+        result = OptionalOAuth2Authentication()._resolve_valid_access_token(token.token)
+        assert result is None

--- a/testbed/core/tests/test_api.py
+++ b/testbed/core/tests/test_api.py
@@ -467,7 +467,7 @@ and the NON-NORMATIVE session-stored token path, which is demo-scoped by constru
 
 These cover the session path and the token-validation step it relies on.
 """
-class TestOptionalAuthenticationEnvironmentScoping:
+class TestOptionalAuthenticationSessionPath:
 
     # A valid session-stored token authenticates via the session path.
     @pytest.mark.django_db

--- a/testbed/core/tests/test_api.py
+++ b/testbed/core/tests/test_api.py
@@ -2,7 +2,7 @@ import pytest
 from rest_framework.test import APIClient
 from rest_framework import status
 from django.urls import reverse
-from django.test import RequestFactory, override_settings
+from django.test import RequestFactory
 from django.contrib.auth import get_user_model
 from oauth2_provider.models import Application, AccessToken
 from testbed.core.models import Actor, Following, Followers
@@ -458,29 +458,20 @@ class TestLOLACollectionDiscovery:
                 assert "followers" not in data
 
 
-# OptionalOAuth2Authentication session-auth gate
+# OptionalOAuth2Authentication session-auth path
 
 """
 Auth class has two paths:
 Normative Authorization: Bearer header (covered by the existing header tests in this file and by test_token_actor_binding.py)
-and the NON-NORMATIVE session-stored token path, gated by LOLA_ALLOW_SESSION_TOKEN_AUTH.
+and the NON-NORMATIVE session-stored token path, which is demo-scoped by construction.
+
+These cover the session path and the token-validation step it relies on.
 """
 class TestOptionalAuthenticationEnvironmentScoping:
 
-    # With the flag off, session auth is skipped before any session read
+    # A valid session-stored token authenticates via the session path.
     @pytest.mark.django_db
-    @override_settings(LOLA_ALLOW_SESSION_TOKEN_AUTH=False)
-    def test_session_path_disabled_by_environment(self):
-        request = RequestFactory().get("/api/actors/1/")
-        request.session = {}  # would carry a token if the path were enabled
-
-        result = OptionalOAuth2Authentication()._try_session_auth(request)
-        assert result is None
-
-    # With the flag on, a valid session-stored token authenticates
-    @pytest.mark.django_db
-    @override_settings(LOLA_ALLOW_SESSION_TOKEN_AUTH=True)
-    def test_session_path_enabled_authenticates(self):
+    def test_session_path_authenticates(self):
         token = AccessTokenFactory(lola_scope=True)
         request = RequestFactory().get("/api/actors/1/")
         request.session = {}
@@ -491,7 +482,7 @@ class TestOptionalAuthenticationEnvironmentScoping:
         result = OptionalOAuth2Authentication()._try_session_auth(request)
         assert result == (token.user, token)
 
-    # An expired token is rejected by the session path's validation step
+    # An expired token is rejected by the session path's validation step.
     @pytest.mark.django_db
     def test_resolve_valid_access_token_rejects_expired(self):
         token = AccessTokenFactory(lola_scope=True, expired=True)

--- a/testbed/settings/base.py
+++ b/testbed/settings/base.py
@@ -252,23 +252,7 @@ OAUTH2_PROVIDER = {
 
 OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = "oauth2_provider.AccessToken"
 
-"""
-LOLA convenience authentication paths.
-
-OptionalOAuth2Authentication supports three ways to present a portability token
-1. Authorization: Bearer header (the only normative LOLA path)
-2. ?auth_token= query string
-3. Token stored in the Django session.
-
-The last two exist solely so this testbed can demo the process involving a destination-server
-and so developers can click links during local testing.
-They are NOT part of the source-server contract.
-
-Both flags default to False here so that any settings module that forgets to
-opt in fails CLOSED (only the Bearer header authenticates).
-"""
-LOLA_ALLOW_URL_TOKEN_AUTH = False
-LOLA_ALLOW_SESSION_TOKEN_AUTH = False
+LOLA_ALLOW_SESSION_TOKEN_AUTH = True
 
 # Configure REST framework to use OAuth2 authentication
 REST_FRAMEWORK = {

--- a/testbed/settings/base.py
+++ b/testbed/settings/base.py
@@ -252,6 +252,24 @@ OAUTH2_PROVIDER = {
 
 OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = "oauth2_provider.AccessToken"
 
+"""
+LOLA convenience authentication paths.
+
+OptionalOAuth2Authentication supports three ways to present a portability token
+1. Authorization: Bearer header (the only normative LOLA path)
+2. ?auth_token= query string
+3. Token stored in the Django session.
+
+The last two exist solely so this testbed can demo the process involving a destination-server
+and so developers can click links during local testing.
+They are NOT part of the source-server contract.
+
+Both flags default to False here so that any settings module that forgets to
+opt in fails CLOSED (only the Bearer header authenticates).
+"""
+LOLA_ALLOW_URL_TOKEN_AUTH = False
+LOLA_ALLOW_SESSION_TOKEN_AUTH = False
+
 # Configure REST framework to use OAuth2 authentication
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [

--- a/testbed/settings/base.py
+++ b/testbed/settings/base.py
@@ -252,8 +252,6 @@ OAUTH2_PROVIDER = {
 
 OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = "oauth2_provider.AccessToken"
 
-LOLA_ALLOW_SESSION_TOKEN_AUTH = True
-
 # Configure REST framework to use OAuth2 authentication
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [


### PR DESCRIPTION
Closes #264 

This PR completely reviews `OptionalOAuth2Authentication`.

The auth class now accepts a portability token two ways:
1. The normative `Authorization: Bearer` header
2. Demo-only session-stored token — and the leak-prone `?auth_token=` query-string path is removed entirely.

For testing (and demoing) purposes I previously created a third auth path that included `?auth_token=` in the URLs. With this update, the session path already covers the demo without that exposure.

I deleted `_authenticate_with_url_token`. The session path stays but is demo-scoped by construction (only the demo flow populates the session; cookie-bound; re-validated each request; `?public_only`-suppressed), so it needs no flag or config. The token-validation step is kept as `_resolve_valid_access_token`. The demo `oauth_token_exchange.html` authenticates via session (no token in any URL).