### PR TITLE
Update validate_lola_access() to enforce actor binding consistently across dual-mode endpoints

### DIFF
--- a/docs/lola-authentication.md
+++ b/docs/lola-authentication.md
@@ -414,32 +414,51 @@ The binding is persisted inside the same `transaction.atomic()` block DOT
 
 **Location**: `testbed/core/views/decorators.py` - `validate_lola_access`
 
-Every LOLA-gated endpoint calls `validate_lola_access(request)`, which now
-runs two layers:
+Every LOLA actor-scoped endpoint calls `validate_lola_access(request, ...)`,
+which runs two layers governed by *different* conditions:
 
-- **Layer 1 - Scope check.** Rejects requests without
+- **Layer 1 - Scope presence (controlled by `required_scope`).** Strict
+  endpoints (`required_scope=True`) reject requests without
   `activitypub_account_portability` scope with 403 `insufficient_scope`.
-- **Layer 2 - Actor binding check.** For portability-scoped requests, reads
-  the requested actor pk from `request.resolver_match.kwargs["pk"]` and
-  compares it to `request.auth.actor_binding.actor_id`. Mismatches, missing
-  binding rows, and requests without a URL pk all return 403 `actor_mismatch`
-  (fail closed).
+  Dual-mode endpoints (`required_scope=False`) skip this layer so public
+  traffic passes through to their public response.
+- **Layer 2 - Actor binding check (runs whenever a portability token is
+  present, regardless of `required_scope`).** Reads the requested actor pk from
+  `request.resolver_match.kwargs["pk"]` and compares it to
+  `request.auth.actor_binding.actor_id`. Mismatches, missing binding rows,
+  a missing URL pk, and a claimed scope with no token object all return 403
+  `actor_mismatch` (fail closed).
 
 The binding check covers both `OptionalOAuth2Authentication` paths
-(Authorization header and session) because both set `request.auth` to the same
-`AccessToken` instance.
+(Authorization header and the demo-only session token) because both set
+`request.auth` to the same `AccessToken` instance.
 
 ### Endpoints Enforcing Binding
 
-The four currently LOLA-gated endpoints (those calling `validate_lola_access(request, required_scope=True)`):
+Token-to-actor binding is enforced on **every** actor-scoped LOLA endpoint that
+can expose scope-gated data — both the strict collections and the dual-mode
+endpoints.
+
+**Strict endpoints** — `validate_lola_access(request, required_scope=True)`.
+No portability scope ⇒ 403 `insufficient_scope`; wrong actor ⇒ 403
+`actor_mismatch`:
 
 - `GET /api/actors/<pk>/followers/`
-- `GET /api/actors/<pk>/content/`
+- `GET /api/actors/<pk>/content/` (and `…/migration/content/`)
 - `GET /api/actors/<pk>/liked/`
-- `GET /api/actors/<pk>/blocked/`
+- `GET /api/actors/<pk>/blocked/` (and `…/migration/blocked/`)
 
-Actor-detail, outbox, and following are intentionally out of scope for this
-enforcement pass (see `personal-development/TRACKING-NOTES.md`).
+**Dual-mode endpoints** — `validate_lola_access(request, required_scope=False)`.
+No token ⇒ public response (200); a portability token bound to a *different*
+actor ⇒ 403 `actor_mismatch`:
+
+- `GET /api/actors/<pk>/` (actor detail)
+- `GET /api/actors/<pk>/outbox/` (and `…/migration/outbox/`)
+- `GET /api/actors/<pk>/following/` (and `…/migration/following/`)
+
+This means a portability token bound to actor A can never read actor B's
+augmented data — including B's private outbox activities — while anonymous
+ActivityPub federation against the dual-mode endpoints is unaffected.
 
 ### actor_mismatch Response
 
@@ -484,7 +503,10 @@ Two core ActivityPub endpoints have been enhanced with LOLA authentication suppo
 |---------------------|------------------|
 | ❌ Unauthenticated | Basic ActivityPub Actor (no LOLA fields) |
 | ✅ OAuth without portability scope | Basic ActivityPub Actor (no LOLA fields) |
-| ✅ OAuth with portability scope | Enhanced Actor with LOLA discovery fields |
+| ✅ Portability token bound to **this** actor | Enhanced Actor with LOLA discovery fields |
+| ⛔ Portability token bound to a **different** actor | `403 actor_mismatch` (dual-mode binding) |
+
+This is a dual-mode endpoint: it calls `validate_lola_access(request, required_scope=False)`, so anonymous access stays a normal public response, but a portability token must be bound to `<pk>` before the LOLA fields are exposed (see [Endpoints Enforcing Binding](#endpoints-enforcing-binding)).
 
 #### LOLA Fields Added (when authenticated with portability scope)
 
@@ -538,7 +560,7 @@ Two core ActivityPub endpoints have been enhanced with LOLA authentication suppo
 | Following | LOLA-gated | Public once discovered |
 | Followers | LOLA-gated | LOLA-gated |
 
-**Following Collection**: Public access once URL is discovered (follows ActivityPub standard)
+**Following Collection**: Public access once URL is discovered (follows ActivityPub standard). It is a dual-mode endpoint, so anonymous reads return the public collection, but a portability token presented here must be bound to `<pk>` (else `403 actor_mismatch`, Task 10.3). The same applies to the advertised `…/migration/following/` route (same view).
 **Followers Collection**: LOLA authentication required for both discovery and access (privacy-sensitive data)
 
 #### Response Format
@@ -573,7 +595,10 @@ Two core ActivityPub endpoints have been enhanced with LOLA authentication suppo
 |---------------------|-------------------|
 | ❌ Unauthenticated | Public activities only |
 | ✅ OAuth without portability scope | Public activities only |
-| ✅ OAuth with portability scope | ALL activities (public + private) |
+| ✅ Portability token bound to **this** actor | ALL activities (public + private) |
+| ⛔ Portability token bound to a **different** actor | `403 actor_mismatch` (dual-mode binding) |
+
+Like actor-detail, this is a dual-mode endpoint (`validate_lola_access(request, required_scope=False)`): a mis-bound portability token is rejected rather than served another actor's private activities. The same applies to the advertised `…/migration/outbox/` route (same view).
 
 #### Response Structure
 

--- a/testbed/core/tests/conftest.py
+++ b/testbed/core/tests/conftest.py
@@ -8,6 +8,8 @@ from testbed.core.factories import (
     CreateActivityFactory,
     LikeActivityFactory,
     FollowActivityFactory,
+    AccessTokenFactory,
+    TokenActorBindingFactory,
 )
 from testbed.core.models import Actor, User
 from testbed.core.utils.actor_utils import populate_source_actor_outbox
@@ -22,6 +24,21 @@ def create_isolated_actor(username_prefix, role=None):
         username=f"{username_prefix}_actor",
         role=role
     )
+
+"""
+Create a portability token bound to an actor.
+Both the strict and the dual-mode LOLA endpoints enforce token-to-actor binding
+
+When `user` is given, the token is issued for that user so token.user matches actor.user;
+otherwise the factory creates a fresh token user. Only the token<->actor binding is what
+validate_lola_access checks, so both shapes satisfy the gate.
+"""
+def bind_portability_token(actor, user=None):
+    if user is not None:
+        token = AccessTokenFactory(lola_scope=True, user=user)
+        TokenActorBindingFactory(token=token, actor=actor)
+        return token
+    return TokenActorBindingFactory(actor=actor).token
 
 # Helper function to create an isolated LikeActivity with remote object
 def create_isolated_remote_like(username_prefix="remote_like_test"):

--- a/testbed/core/tests/test_api.py
+++ b/testbed/core/tests/test_api.py
@@ -91,7 +91,10 @@ class TestLOLAAuthenticationAPI:
     @pytest.mark.django_db
     def test_outbox_content_filtering_by_authentication(self, mock_request):
         actor = create_isolated_actor("outbox_filtering_test")
-        lola_token = AccessTokenFactory(lola_scope=True)
+        # Dual-mode endpoints enforce token-to-actor binding.
+        # Bind the portability token to this actor so it is not rejected with
+        # actor_mismatch when a LOLA token is present.
+        lola_token = TokenActorBindingFactory(actor=actor).token
         client = APIClient()
         
         # Test unauthenticated outbox (public activities only)
@@ -162,7 +165,10 @@ class TestLOLAAuthenticationAPI:
     @pytest.mark.django_db
     def test_content_type_headers_set_correctly(self):
         actor = create_isolated_actor("content_type_test")
-        lola_token = AccessTokenFactory(lola_scope=True)
+        # Dual-mode endpoints enforce token-to-actor binding.
+        # Bind the portability token to this actor so it is not rejected with
+        # actor_mismatch when a LOLA token is present.
+        lola_token = TokenActorBindingFactory(actor=actor).token
         client = APIClient()
         client.credentials(HTTP_AUTHORIZATION=f'Bearer {lola_token.token}')
         
@@ -404,7 +410,10 @@ class TestLOLACollectionDiscovery:
     @pytest.mark.django_db
     def test_collection_urls_appear_only_with_lola_auth(self):
         actor = create_isolated_actor("discovery_test")
-        lola_token = AccessTokenFactory(lola_scope=True)
+        # Dual-mode endpoints enforce token-to-actor binding.
+        # Bind the portability token to this actor so it is not rejected with
+        # actor_mismatch when a LOLA token is present.
+        lola_token = TokenActorBindingFactory(actor=actor).token
         
         # Public request should not show collection URLs
         public_client = APIClient()
@@ -429,7 +438,10 @@ class TestLOLACollectionDiscovery:
     @pytest.mark.django_db
     def test_collection_discovery_demonstrates_lola_privacy_model(self):
         actor = create_isolated_actor("privacy_demo")
-        lola_token = AccessTokenFactory(lola_scope=True)
+        # Dual-mode endpoints enforce token-to-actor binding.
+        # Bind the portability token to this actor so it is not rejected with
+        # actor_mismatch when a LOLA token is present.
+        lola_token = TokenActorBindingFactory(actor=actor).token
         basic_token = AccessTokenFactory(scope='read write')
         
         # Test three authentication states

--- a/testbed/core/tests/test_api.py
+++ b/testbed/core/tests/test_api.py
@@ -10,9 +10,8 @@ from testbed.core.factories import (
     ActorFactory,
     ApplicationFactory,
     AccessTokenFactory,
-    TokenActorBindingFactory,
 )
-from testbed.core.tests.conftest import create_isolated_actor
+from testbed.core.tests.conftest import bind_portability_token, create_isolated_actor
 from testbed.core.json_ld_utils import (
     build_basic_context,
     build_actor_context,
@@ -91,10 +90,7 @@ class TestLOLAAuthenticationAPI:
     @pytest.mark.django_db
     def test_outbox_content_filtering_by_authentication(self, mock_request):
         actor = create_isolated_actor("outbox_filtering_test")
-        # Dual-mode endpoints enforce token-to-actor binding.
-        # Bind the portability token to this actor so it is not rejected with
-        # actor_mismatch when a LOLA token is present.
-        lola_token = TokenActorBindingFactory(actor=actor).token
+        lola_token = bind_portability_token(actor)
         client = APIClient()
         
         # Test unauthenticated outbox (public activities only)
@@ -165,10 +161,7 @@ class TestLOLAAuthenticationAPI:
     @pytest.mark.django_db
     def test_content_type_headers_set_correctly(self):
         actor = create_isolated_actor("content_type_test")
-        # Dual-mode endpoints enforce token-to-actor binding.
-        # Bind the portability token to this actor so it is not rejected with
-        # actor_mismatch when a LOLA token is present.
-        lola_token = TokenActorBindingFactory(actor=actor).token
+        lola_token = bind_portability_token(actor)
         client = APIClient()
         client.credentials(HTTP_AUTHORIZATION=f'Bearer {lola_token.token}')
         
@@ -340,10 +333,7 @@ class TestFollowersCollectionEndpoint:
     @pytest.mark.django_db
     def test_followers_collection_with_lola_token(self):
         target_actor, follower1, follower2 = self.setup_followers_data()
-        # Bind the token to target_actor so the Task 9.2 token-to-actor
-        # binding check (LOLA Section 5 MUST) succeeds for this request.
-        binding = TokenActorBindingFactory(actor=target_actor)
-        lola_token = binding.token
+        lola_token = bind_portability_token(target_actor)
 
         client = APIClient()
         client.credentials(HTTP_AUTHORIZATION=f'Bearer {lola_token.token}')
@@ -381,8 +371,7 @@ class TestFollowersCollectionEndpoint:
     @pytest.mark.django_db
     def test_followers_collection_includes_complete_actor_data(self):
         target_actor, follower1, follower2 = self.setup_followers_data()
-        binding = TokenActorBindingFactory(actor=target_actor)
-        lola_token = binding.token
+        lola_token = bind_portability_token(target_actor)
 
         client = APIClient()
         client.credentials(HTTP_AUTHORIZATION=f'Bearer {lola_token.token}')
@@ -410,10 +399,7 @@ class TestLOLACollectionDiscovery:
     @pytest.mark.django_db
     def test_collection_urls_appear_only_with_lola_auth(self):
         actor = create_isolated_actor("discovery_test")
-        # Dual-mode endpoints enforce token-to-actor binding.
-        # Bind the portability token to this actor so it is not rejected with
-        # actor_mismatch when a LOLA token is present.
-        lola_token = TokenActorBindingFactory(actor=actor).token
+        lola_token = bind_portability_token(actor)
         
         # Public request should not show collection URLs
         public_client = APIClient()
@@ -438,10 +424,7 @@ class TestLOLACollectionDiscovery:
     @pytest.mark.django_db
     def test_collection_discovery_demonstrates_lola_privacy_model(self):
         actor = create_isolated_actor("privacy_demo")
-        # Dual-mode endpoints enforce token-to-actor binding.
-        # Bind the portability token to this actor so it is not rejected with
-        # actor_mismatch when a LOLA token is present.
-        lola_token = TokenActorBindingFactory(actor=actor).token
+        lola_token = bind_portability_token(actor)
         basic_token = AccessTokenFactory(scope='read write')
         
         # Test three authentication states

--- a/testbed/core/tests/test_lola_actor.py
+++ b/testbed/core/tests/test_lola_actor.py
@@ -217,7 +217,6 @@ def test_public_vs_authenticated_response_comparison():
     # actor-detail is dual-mode and enforces token-to-actor binding when a
     # LOLA token is present, so an unbound token would be rejected with actor_mismatch.
     token = AccessTokenFactory(lola_scope=True, user=user)
-    token = AccessTokenFactory(lola_scope=True, user=user)
     TokenActorBindingFactory(token=token, actor=actor)
 
     client.credentials(HTTP_AUTHORIZATION=f'Bearer {token.token}')

--- a/testbed/core/tests/test_lola_actor.py
+++ b/testbed/core/tests/test_lola_actor.py
@@ -93,8 +93,11 @@ def test_actor_with_portability_token_includes_migration():
     user = UserWithActorsFactory()
     actor = Actor.objects.get(user=user, role=Actor.ROLE_SOURCE)
     
-    # Create OAuth token with portability scope
-    token = AccessTokenFactory(lola_scope=True)
+    # Create a portability token bound to this actor.
+    # actor-detail is dual-mode and enforces token-to-actor binding when a
+    # LOLA token is present, so an unbound token would be rejected with actor_mismatch.
+    token = AccessTokenFactory(lola_scope=True, user=user)
+    TokenActorBindingFactory(token=token, actor=actor)
     
     # Make authenticated request
     client.credentials(HTTP_AUTHORIZATION=f'Bearer {token.token}')
@@ -161,8 +164,11 @@ def test_migration_urls_point_to_dedicated_migration_routes():
     user = UserWithActorsFactory()
     actor = Actor.objects.get(user=user, role=Actor.ROLE_SOURCE)
     
-    # Create OAuth token with portability scope
-    token = AccessTokenFactory(lola_scope=True)
+    # Create a portability token bound to this actor.
+    # actor-detail is dual-mode and enforces token-to-actor binding when a
+    # LOLA token is present, so an unbound token would be rejected with actor_mismatch.
+    token = AccessTokenFactory(lola_scope=True, user=user)
+    TokenActorBindingFactory(token=token, actor=actor)
     
     client.credentials(HTTP_AUTHORIZATION=f'Bearer {token.token}')
     response = client.get(f'/api/actors/{actor.id}/')
@@ -207,9 +213,13 @@ def test_public_vs_authenticated_response_comparison():
     public_response = client.get(f'/api/actors/{actor.id}/')
     public_data = public_response.json()
     
-    # Get authenticated response with portability token
-    token = AccessTokenFactory(lola_scope=True)
-    
+    # Create a portability token bound to this actor.
+    # actor-detail is dual-mode and enforces token-to-actor binding when a
+    # LOLA token is present, so an unbound token would be rejected with actor_mismatch.
+    token = AccessTokenFactory(lola_scope=True, user=user)
+    token = AccessTokenFactory(lola_scope=True, user=user)
+    TokenActorBindingFactory(token=token, actor=actor)
+
     client.credentials(HTTP_AUTHORIZATION=f'Bearer {token.token}')
     auth_response = client.get(f'/api/actors/{actor.id}/')
     auth_data = auth_response.json()

--- a/testbed/core/tests/test_lola_actor.py
+++ b/testbed/core/tests/test_lola_actor.py
@@ -4,8 +4,8 @@ from testbed.core.models import Actor
 from testbed.core.factories import (
     UserWithActorsFactory,
     AccessTokenFactory,
-    TokenActorBindingFactory,
 )
+from testbed.core.tests.conftest import bind_portability_token
 
 """
 LOLA Compliance Tests for Actor Endpoint
@@ -93,11 +93,7 @@ def test_actor_with_portability_token_includes_migration():
     user = UserWithActorsFactory()
     actor = Actor.objects.get(user=user, role=Actor.ROLE_SOURCE)
     
-    # Create a portability token bound to this actor.
-    # actor-detail is dual-mode and enforces token-to-actor binding when a
-    # LOLA token is present, so an unbound token would be rejected with actor_mismatch.
-    token = AccessTokenFactory(lola_scope=True, user=user)
-    TokenActorBindingFactory(token=token, actor=actor)
+    token = bind_portability_token(actor, user=user)
     
     # Make authenticated request
     client.credentials(HTTP_AUTHORIZATION=f'Bearer {token.token}')
@@ -164,11 +160,7 @@ def test_migration_urls_point_to_dedicated_migration_routes():
     user = UserWithActorsFactory()
     actor = Actor.objects.get(user=user, role=Actor.ROLE_SOURCE)
     
-    # Create a portability token bound to this actor.
-    # actor-detail is dual-mode and enforces token-to-actor binding when a
-    # LOLA token is present, so an unbound token would be rejected with actor_mismatch.
-    token = AccessTokenFactory(lola_scope=True, user=user)
-    TokenActorBindingFactory(token=token, actor=actor)
+    token = bind_portability_token(actor, user=user)
     
     client.credentials(HTTP_AUTHORIZATION=f'Bearer {token.token}')
     response = client.get(f'/api/actors/{actor.id}/')
@@ -190,10 +182,9 @@ def test_dedicated_migration_routes_resolve():
     user = UserWithActorsFactory()
     actor = Actor.objects.get(user=user, role=Actor.ROLE_SOURCE)
 
-    # LOLA-gated migration routes (content, blocked) enforce token-to-actor
-    # binding via validate_lola_access, so bind a portability token to this actor.
-    token = AccessTokenFactory(lola_scope=True, user=user)
-    TokenActorBindingFactory(token=token, actor=actor)
+    # The migration routes enforce token-to-actor binding, so bind a portability
+    # token to this actor (an unbound token would be rejected with actor_mismatch).
+    token = bind_portability_token(actor, user=user)
     client.credentials(HTTP_AUTHORIZATION=f'Bearer {token.token}')
 
     # All four advertised migration URLs must resolve (routed and implemented)
@@ -213,11 +204,7 @@ def test_public_vs_authenticated_response_comparison():
     public_response = client.get(f'/api/actors/{actor.id}/')
     public_data = public_response.json()
     
-    # Create a portability token bound to this actor.
-    # actor-detail is dual-mode and enforces token-to-actor binding when a
-    # LOLA token is present, so an unbound token would be rejected with actor_mismatch.
-    token = AccessTokenFactory(lola_scope=True, user=user)
-    TokenActorBindingFactory(token=token, actor=actor)
+    token = bind_portability_token(actor, user=user)
 
     client.credentials(HTTP_AUTHORIZATION=f'Bearer {token.token}')
     auth_response = client.get(f'/api/actors/{actor.id}/')

--- a/testbed/core/tests/test_token_actor_binding.py
+++ b/testbed/core/tests/test_token_actor_binding.py
@@ -203,3 +203,54 @@ def test_bearer_cross_actor_denied():
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.data["error_code"] == "actor_mismatch"
+
+
+"""
+Dual-mode binding enforcement
+
+The dual-mode views (actor_detail, portability_outbox_detail, following_collection)
+stay publicly readable but must reject a portability token bound to a different actor.
+Public access and same-actor access are already exercised by the public and bound-token tests in
+test_api.py / test_lola_actor.py, this guarantee to assert here is the cross-actor denial.
+
+One representative route per dual-mode view. The migration/outbox and
+migration/following routes resolve to these same views (proven by
+test_dedicated_migration_routes_resolve), so they share this enforcement.
+"""
+DUAL_MODE_ROUTE_NAMES = [
+    "actor-detail",
+    "actor-outbox",
+    "following-collection",
+]
+
+# A portability token bound to actor A is rejected on actor B's dual-mode endpoints
+@pytest.mark.django_db
+@pytest.mark.parametrize("route_name", DUAL_MODE_ROUTE_NAMES)
+def test_dual_mode_cross_actor_denied(route_name):    
+    binding = TokenActorBindingFactory()  # token bound to actor A
+    user_b = UserOnlyFactory()
+    actor_b = Actor.objects.create(
+        user=user_b, username=f"{user_b.username}_src", role=Actor.ROLE_SOURCE
+    )
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {binding.token.token}")
+    response = client.get(reverse(route_name, kwargs={"pk": actor_b.pk}))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.data["error_code"] == "actor_mismatch"
+
+
+# Portability scope claimed with no token object is denied (fail closed)
+@pytest.mark.django_db
+def test_scope_claimed_without_token_fails_closed():
+    binding = TokenActorBindingFactory()
+    request = _make_lola_request(binding.actor, binding.token)
+    # Anomalous state: the scope flag is set but no token object is present, so
+    # no binding can be verified. The gate must deny, not grant.
+    request.auth = None
+
+    result = validate_lola_access(request)
+    assert result["valid"] is False
+    assert result["error_response"].status_code == 403
+    assert result["error_response"].data["error_code"] == "actor_mismatch"

--- a/testbed/core/views/api.py
+++ b/testbed/core/views/api.py
@@ -60,6 +60,14 @@ def actor_detail(request, pk):
     except Actor.DoesNotExist:
         return build_actor_not_found_error(pk, request)
 
+    # Dual-mode gate: public access is allowed (required_scope=False), but a portability token
+    # must be bound to this actor before its scope-gated discovery surface is exposed (LOLA Section 5).
+    # A token bound to another actor is rejected with 403 actor_mismatch
+    # instead of leaking actor <pk>'s migration object / collection URLs.
+    validation_result = validate_lola_access(request, required_scope=False)
+    if not validation_result["valid"]:
+        return validation_result["error_response"]
+
     # Build standardized authentication context
     auth_context = build_auth_context(request)
 
@@ -80,6 +88,10 @@ def portability_outbox_detail(request, pk):
         outbox = PortabilityOutbox.objects.get(actor_id=pk)
     except PortabilityOutbox.DoesNotExist:
         return build_actor_not_found_error(pk, request)
+
+    validation_result = validate_lola_access(request, required_scope=False)
+    if not validation_result["valid"]:
+        return validation_result["error_response"]
 
     # Build standardized authentication context
     auth_context = build_auth_context(request)
@@ -105,6 +117,10 @@ def following_collection(request, pk):
         actor = Actor.objects.get(pk=pk)
     except Actor.DoesNotExist:
         return build_actor_not_found_error(pk, request)
+
+    validation_result = validate_lola_access(request, required_scope=False)
+    if not validation_result["valid"]:
+        return validation_result["error_response"]
 
     # Get all active following relationships for this actor
     following_qs = Following.objects.filter(

--- a/testbed/core/views/decorators.py
+++ b/testbed/core/views/decorators.py
@@ -20,36 +20,46 @@ def validate_lola_access(request, required_scope=True):
     """
     Scope gate and actor binding check for LOLA-protected endpoints.
 
-    Two-layer check (both layers apply when required_scope=True):
+    Two-layer check, each regulated by a different condition:
 
-    Layer 1 - Scope validation:
-        Confirms the request carries a token with the activitypub_account_portability
-        scope. Returns 403 insufficient_scope if not.
+    Layer 1 - Scope presence (controlled by `required_scope`):
+        Strict endpoints (required_scope=True) MUST carry a token with the activitypub_account_portability scope.
+        Returns 403 insufficient_scope otherwise.
+        Dual-mode endpoints (required_scope=False) skip this layer so
+        unauthenticated/public traffic falls through to their public response.
 
     Layer 2 - Actor binding enforcement (LOLA Section 5 MUST):
-        Confirms the token is bound to the Actor whose <pk> appears in the URL.
-        Returns 403 actor_mismatch if not.
+        Runs whenever a portability token is present (request.has_portability_scope) -- regardless of required_scope.
+        A dual-mode endpoint stays publicly readable, but the moment a portability token is supplied it must be bound
+        to the Actor whose <pk> is in the URL, or the request is rejected with 403 actor_mismatch.
 
-        LOLA Section 5: "This scope MUST be limited to an account - if there is
-        more than one account on the source server, the source server MUST NOT
-        allow access to any other accounts than the one granted."
+        Binding is persisted at token issuance by ActivityPubOAuth2Validator._save_bearer_token (the write side).
+        This gate is the read/enforcement side. The check covers both OptionalOAuth2Authentication paths (Authorization header
+        and the demo-only session token) because both set request.auth to the same AccessToken instance, so
+        request.auth.actor_binding is available whenever request.has_portability_scope is True.
 
-        This check covers all three authentication paths because
-        OptionalOAuth2Authentication (header, URL param, session) all produce the
-        same request.auth object, so request.auth.actor_binding is available
-        whenever request.has_portability_scope is True.
+    Mode summary:
+        required_scope=True  (strict):    no token -> 403 insufficient_scope;
+                                          token bound to other actor -> 403 actor_mismatch.
+        required_scope=False (dual-mode): no token -> public access (valid);
+                                          token bound to other actor -> 403 actor_mismatch.
 
     Args:
         request: HTTP request with OAuth authentication attributes set by
             OptionalOAuth2Authentication. request.auth is the AccessToken.
         required_scope: Whether the LOLA portability scope is required (default: True).
+            Pass False for dual-mode endpoints that also serve public traffic but
+            must still reject mis-bound portability tokens.
 
     Returns:
         dict: {'valid': True} on success, or
               {'valid': False, 'error_response': Response} on any failure.
     """
-    # Layer 1: scope check
-    if required_scope and not getattr(request, "has_portability_scope", False):
+
+    has_scope = bool(getattr(request, "has_portability_scope", False))
+
+    # Layer 1: scope presence (strict endpoints only)
+    if required_scope and not has_scope:
         logger.warning("LOLA access denied: insufficient_scope for %s", request.path)
         return {
             "valid": False,
@@ -60,37 +70,48 @@ def validate_lola_access(request, required_scope=True):
             ),
         }
 
-    # Layer 2: actor binding check (only when a portability token is present)
-    if required_scope and getattr(request, "has_portability_scope", False):
-        token = getattr(request, "auth", None)
-        url_pk = _get_url_pk(request)
+    # No portability token
+    if not has_scope:
+        return {"valid": True}
 
-        if url_pk is None:
-            # All LOLA-gated endpoints are actor-scoped with <pk> in the
-            # URL. A missing pk here means the decorator is being invoked from an
-            # unexpected endpoint shape. Fail closed rather than silently skip
-            # a LOLA Section 5 MUST.
-            logger.warning(
-                "LOLA access denied: actor binding check invoked without URL pk "
-                "path=%s",
-                request.path,
-            )
-            return {
-                "valid": False,
-                "error_response": build_actor_mismatch_error(request=request),
-            }
-
-        if token is not None:
-            mismatch = _check_actor_binding(request, token, url_pk)
-            if mismatch is not None:
-                return mismatch
-
-        logger.info(
-            "LOLA access granted: scope=activitypub_account_portability "
-            "endpoint=%s actor_pk=%s",
+    # Layer 2: actor binding. Reached whenever a portability token is present, so dual-mode
+    # endpoints cannot leak another actor's augmented data to a token bound to a different actor.
+    url_pk = _get_url_pk(request)
+    if url_pk is None:
+        # Fail closed. All LOLA actor-scoped endpoints carry <pr> in the URL, so this should not occur in normal operation.
+        logger.warning(
+            "LOLA access denied: actor binding check invoked without URL pk path=%s",
             request.path,
-            url_pk,
         )
+        return {
+            "valid": False,
+            "error_response": build_actor_mismatch_error(request=request),
+        }
+
+    token = getattr(request, "auth", None)
+    if token is None:
+        # In normal flows has_portability_scope is derived from the token, so this state should not occur;
+        # if it does the binding is unverifiable -> fail closed rather than grant on an unverifiable claim.
+        logger.warning(
+            "LOLA access denied: portability scope claimed without a token object "
+            "path=%s",
+            request.path,
+        )
+        return {
+            "valid": False,
+            "error_response": build_actor_mismatch_error(request=request),
+        }
+
+    mismatch = _check_actor_binding(request, token, url_pk)
+    if mismatch is not None:
+        return mismatch
+
+    logger.info(
+        "LOLA access granted: scope=activitypub_account_portability "
+        "endpoint=%s actor_pk=%s",
+        request.path,
+        url_pk,
+    )
 
     return {"valid": True}
 


### PR DESCRIPTION
Closes #266 

This PR updates the existing `validate_lola_access()` endpoint to continue enforcing LOLA §5 token-to-actor binding consistently across every actor-scoped endpoint.

Currently, a portability token bound to actor A could reactor actor B's LOLA *augmented* dual-mode responses, including B's private outbox activities. This doesn't respect LOLA §5.

Every actor-scoped LOLA endpoint falls into one of two behavioral categories:

**Strict (LOLA-gated) endpoints** — these serve *only* private/privacy-sensitive data and have no meaningful public version:

- `followers`, `content`, `liked`, `blocked`

They each call `validate_lola_access(request, required_scope=True)`. No portability scope → `403 insufficient_scope`. They already enforce token-to-actor binding.

**Dual-mode endpoints** — these serve a *public* ActivityPub response to anonymous callers, and an *augmented* response when a portability token is present:

- `actor_detail` — public: basic Actor; with scope: adds the `migration` object + `outbox`/`following`/`followers`/`liked`/`blocked` URLs.
- `portability_outbox_detail` — public: public activities only; with scope: **all** activities including private.
- `following_collection`— public: following list; with scope: nested actor objects gain migration augmentation.

These three **do not call `validate_lola_access` at all**. They look at `request.has_portability_scope` directly (inside the JSON-LD builders) and augment the response — but they never check **which actor** the token was issued for.
