### PR TITLE
Require https redirect URIs in production and staging

### DIFF
--- a/testbed/core/oauth/forms.py
+++ b/testbed/core/oauth/forms.py
@@ -1,5 +1,8 @@
+from urllib.parse import urlparse
+
 from django import forms
 from oauth2_provider.models import get_application_model
+from oauth2_provider.settings import oauth2_settings
 
 Application = get_application_model()
 
@@ -28,25 +31,39 @@ class OAuthApplicationForm(forms.ModelForm):
             }),
             'redirect_uris': forms.TextInput(attrs={
                 'class': 'form-control', 
-                'placeholder': 'Enter a valid URL (e.g., http://localhost:8000/callback). Add multiples separated by spaces'
+                # https is valid in every environment; production and staging reject http.
+                'placeholder': 'Enter a valid URL (e.g., https://your-service.example/callback). Add multiples separated by spaces'
             }),
         }
     
-    # Ensure redirect URIs are properly formatted
     def clean_redirect_uris(self):
+        """
+        Validate the redirect URLs registered for this OAuth application.
+
+        Accepted schemes come from OAUTH2_PROVIDER["ALLOWED_REDIRECT_URI_SCHEMES"] which is
+        the same setting ActivityPubOAuth2Validator.validate_redirect_uri enforces at
+        authorization time, and that django-oauth-toolkit enforces in Application.clean().
+
+        Production and staging allow https only.
+
+        Returns:
+            str: the space-separated redirect URIs, unchanged, when every one of
+            them uses an allowed scheme.
+        """
         uris = self.cleaned_data.get('redirect_uris', '')
         if not uris:
             raise forms.ValidationError("Redirect URL is required")
-        
-        # Simple validation - could be expanded for more strict checks
+
+        allowed_schemes = [s.lower() for s in oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES]
+        # Rendered into the error message, e.g. "https://" or "http:// or https://"
+        expected_prefixes = " or ".join(f"{scheme}://" for scheme in allowed_schemes)
+
         for uri in uris.split():
-            if not uri.startswith(('http://', 'https://')):
+            # urlparse lowercases the scheme, so HTTPS:// is accepted as https.
+            if urlparse(uri).scheme not in allowed_schemes:
                 raise forms.ValidationError(
-                    "Each URI must start with http:// or https://"
+                    f"Each URL must start with {expected_prefixes}"
                 )
-        
-        if hasattr(self, 'instance') and self.instance and self.instance.authorization_grant_type == 'authorization-code' and not uris:
-            raise forms.ValidationError("Redirect URL is required for authorization code grant type")
         
         return uris
     

--- a/testbed/core/tests/test_oauth_forms.py
+++ b/testbed/core/tests/test_oauth_forms.py
@@ -1,0 +1,56 @@
+"""
+OAuth application settings form.
+"""
+
+import pytest
+
+from django.conf import settings
+from django.test import override_settings
+
+from testbed.core.oauth.forms import OAuthApplicationForm
+
+
+DEFAULT_POLICY = settings.OAUTH2_PROVIDER
+HTTPS_ONLY = {**settings.OAUTH2_PROVIDER, "ALLOWED_REDIRECT_URI_SCHEMES": ["https"]}
+
+
+def _redirect_uri_errors(uri):
+    # Bind the form with `uri` and return its redirect_uris error messages
+    form = OAuthApplicationForm(
+        data={
+            "name": "Test ActivityPub Service",
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret",
+            "redirect_uris": uri,
+        }
+    )
+    form.is_valid()
+    return form.errors.get("redirect_uris", [])
+
+
+# The scheme policy is per environment, so the same URI is valid or not
+# depending on which settings module is active.
+@pytest.mark.parametrize(
+    "policy, uri, expected_message_fragment",
+    [
+        # Local development and CI register http://localhost callbacks.
+        (DEFAULT_POLICY, "http://localhost:8000/callback", None),
+        # If eberything is rejected it would break local development
+        (HTTPS_ONLY, "https://example.com/callback", None),
+        # With production policy http must be refused.
+        (HTTPS_ONLY, "http://example.com/callback", "https://"),
+    ],
+)
+@pytest.mark.django_db
+def test_redirect_uri_scheme_policy_per_environment(policy, uri, expected_message_fragment):
+    with override_settings(OAUTH2_PROVIDER=policy):
+        errors = _redirect_uri_errors(uri)
+
+    if expected_message_fragment is None:
+        assert errors == [], f"{uri} should be accepted under this policy"
+        return
+
+    assert errors, f"{uri} should be rejected under this policy"
+    # The message must describe the actual policy
+    assert expected_message_fragment in errors[0]
+    assert "http:// or" not in errors[0]

--- a/testbed/core/views/oauth_demo.py
+++ b/testbed/core/views/oauth_demo.py
@@ -22,6 +22,7 @@ import requests
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from oauth2_provider.settings import oauth2_settings
 
 from ..json_ld_utils import build_actor_id
 from ..models import Actor
@@ -93,8 +94,18 @@ def test_authorization_view(request):
     host = request.get_host()
     redirect_uri = f"{scheme}://{host}/callback"
 
+    allowed_schemes = [s.lower() for s in oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES]
+    if scheme.lower() not in allowed_schemes:
+        logger.warning(
+            "Demo callback not registered: scheme %r is not allowed in this environment "
+            "(allowed: %s). Browse the site over %s to run the demo. client_id=%s",
+            scheme,
+            allowed_schemes,
+            allowed_schemes[0] if allowed_schemes else "an allowed scheme",
+            application.client_id,
+        )
     # Update the application's redirect URIs if needed
-    if redirect_uri not in application.redirect_uris:
+    elif redirect_uri not in application.redirect_uris:
         if application.redirect_uris:
             application.redirect_uris = f"{application.redirect_uris} {redirect_uri}"
         else:

--- a/testbed/settings/production.py
+++ b/testbed/settings/production.py
@@ -13,6 +13,9 @@ BASE_URL = "https://ap-testbed.dtinit.org"
 # Cloud Run uses X-Forwarded-Proto header for HTTPS detection
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+# HTTPS-only OAuth redirect URIs (LOLA §6.1).
+OAUTH2_PROVIDER["ALLOWED_REDIRECT_URI_SCHEMES"] = ["https"]
+
 # PostgreSQL for production
 DATABASES = {"default": env.db_url("DJ_DATABASE_CONN_STRING")}
 


### PR DESCRIPTION
Part of https://github.com/dtinit/activity-pub-testbed/issues/279 (PR 3/3)

Sets `ALLOWED_REDIRECT_URI_SCHEMES = ['https']` for production and staging.

Prod and stg has been inheriting django-oauth-toolkit's default which accepts `http://` redirect URIs.

The other two changes exist due the changes made on that one:

The form on `oauth/forms.py` previously hardcoded *"Each URI must start with http:// or https://"*.
After the policy change that message becomes wrong in production; a user would follow it and then hit DOT's raw `redirect uri URI Validation error. invalid_scheme` on save. It now derives both the accepted schemes and the message text from the same setting, so the friendly message is the correct one in every environment.

**LOLA/spec**

§6.1: *"The destination MUST fetch data using HTTPS, not HTTP."* That MUST sits on the destination, but a source handing authorization codes to `http://` callbacks undermines it. §5.1 lists `redirect_uri` among the authorization-request parameters the source validates.