### PR TITLE
Correct validator docstrings against observed behavior

### DIFF
--- a/testbed/core/oauth/authentication.py
+++ b/testbed/core/oauth/authentication.py
@@ -176,8 +176,8 @@ class OptionalOAuth2Authentication(OAuth2Authentication):
         """
         Check whether an authenticated token carries LOLA portability scope.
         
-        Delegates to oauth/scopes.py so this request-time check cannot drift
-        from the authorization-time one in ActivityPubOAuth2Validator.validate_scopes.
+        Delegates to oauth/scopes.py so this check cannot drift from our
+        authorization-time one in ActivityPubOAuth2Validator.validate_scopes.
 
         `getattr(token, "scope", None)` covers tokens with no `scope` attribute
         at all, and scope_grants_portability() treats None/empty as "no scope", so

--- a/testbed/core/oauth/validators.py
+++ b/testbed/core/oauth/validators.py
@@ -76,8 +76,9 @@ class ActivityPubOAuth2Validator(OAuth2Validator):
 
         Returns:
             bool: True only when both gates pass. Returning False makes oauthlib
-            raise `InvalidRedirectURIError`, a fatal client error, so DOT renders
-            an error page instead of redirecting.
+            raise `MismatchingRedirectURIError`, a FatalClientError, and DOT
+            answers 400 by re-rendering `oauth2_provider/authorize.html` with the
+            error in context.
         """
         # Gate 1: is it registered?
         valid = super().validate_redirect_uri(client_id, redirect_uri, request, *args, **kwargs)


### PR DESCRIPTION
This was checked against a real authorize request.

`validate_redirect_uri` documented that returning False raises InvalidRedirectURIError and that DOT "renders an error page." which was a bit off. oauthlib raises `MismatchingRedirectURIError` when our validator returns False, and the response is a 400 re-render of oauth2_provider/authorize.html.

Also the scope-check note implied DOT owned the authorization-time check when both validate_scopes calls are ours.